### PR TITLE
chore: add CodeQL SAST scanning to CI (#6)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: CodeQL Security Scanning
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Run weekly on Monday at 08:00 UTC to catch newly published CVEs
+    - cron: '0 8 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (C#)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.x'
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: csharp
+          # Built-in query suites: security-extended catches more than the default
+          queries: security-extended,security-and-quality
+
+      - name: Restore dependencies
+        run: dotnet restore API/API.csproj
+
+      - name: Build (autobuild fallback — explicit build preferred)
+        run: dotnet build API/API.csproj --no-restore --configuration Release
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:csharp'


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/codeql.yml` GitHub Actions workflow
- Triggers on push to `main`, PRs targeting `main`, and weekly (Monday 08:00 UTC) to catch newly published CVEs
- Configured for **C#** analysis with `security-extended` and `security-and-quality` query suites
- Explicit `dotnet build` step ensures CodeQL traces the full compilation rather than relying on autobuild guessing
- Results appear in the **GitHub Security → Code scanning** tab; critical/high severity alerts block the PR check automatically via GitHub's default policy

## Test plan

- [x] All 42 existing unit tests pass (`dotnet test`)
- [x] Confirm CodeQL check appears and passes on this PR in GitHub Actions
- [ ] Verify results are visible in Security tab after first successful run
- [ ] Confirm no false-positive blocking alerts on existing codebase

Closes #6