### PR TITLE
feat: add GET /api/sentiment/trending endpoint

### DIFF
--- a/API/Controllers/SentimentController.cs
+++ b/API/Controllers/SentimentController.cs
@@ -2,6 +2,7 @@ using API.Controllers.DTOs;
 using Application.Features.Sentiment.Commands.AnalyzeSentiment;
 using Application.Features.Sentiment.Queries.GetSentimentHistory;
 using Application.Features.Sentiment.Queries.GetSentimentStats;
+using Application.Features.Sentiment.Queries.GetTrendingSymbols;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
@@ -52,6 +53,20 @@ public class SentimentController(ISender sender) : ControllerBase
         var result = await sender.Send(
             new GetSentimentHistoryQuery(symbol, page, pageSize, from, to), ct);
 
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Top symbols ranked by largest sentiment score shift in the given rolling window.
+    /// </summary>
+    [HttpGet("trending")]
+    [ProducesResponseType(typeof(IReadOnlyList<TrendingSymbolDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetTrending(
+        [FromQuery] int hours = 24,
+        [FromQuery] int limit = 10,
+        CancellationToken ct = default)
+    {
+        var result = await sender.Send(new GetTrendingSymbolsQuery(hours, limit), ct);
         return Ok(result);
     }
 

--- a/Application/Features/Sentiment/Queries/GetTrendingSymbols/GetTrendingSymbolsQuery.cs
+++ b/Application/Features/Sentiment/Queries/GetTrendingSymbols/GetTrendingSymbolsQuery.cs
@@ -1,0 +1,6 @@
+using MediatR;
+
+namespace Application.Features.Sentiment.Queries.GetTrendingSymbols;
+
+public record GetTrendingSymbolsQuery(int Hours = 24, int Limit = 10)
+    : IRequest<IReadOnlyList<TrendingSymbolDto>>;

--- a/Application/Features/Sentiment/Queries/GetTrendingSymbols/GetTrendingSymbolsQueryHandler.cs
+++ b/Application/Features/Sentiment/Queries/GetTrendingSymbols/GetTrendingSymbolsQueryHandler.cs
@@ -1,0 +1,58 @@
+using Domain.Entities;
+using Domain.Interfaces;
+using MediatR;
+
+namespace Application.Features.Sentiment.Queries.GetTrendingSymbols;
+
+public class GetTrendingSymbolsQueryHandler(ISentimentRepository repository)
+    : IRequestHandler<GetTrendingSymbolsQuery, IReadOnlyList<TrendingSymbolDto>>
+{
+    public async Task<IReadOnlyList<TrendingSymbolDto>> Handle(
+        GetTrendingSymbolsQuery query,
+        CancellationToken ct)
+    {
+        var now = DateTime.UtcNow;
+        var windowStart = now.AddHours(-query.Hours);
+        var midpoint = now.AddHours(-query.Hours / 2.0);
+
+        var analyses = await repository.GetRecentAsync(windowStart, ct);
+
+        if (analyses.Count == 0)
+            return [];
+
+        var grouped = analyses.GroupBy(a => a.Symbol.Value);
+
+        var results = grouped
+            .Select(g => ComputeTrend(g.Key, g.ToList(), midpoint))
+            .OrderByDescending(t => Math.Abs(t.Delta))
+            .Take(query.Limit)
+            .ToList();
+
+        return results;
+    }
+
+    private static TrendingSymbolDto ComputeTrend(
+        string symbol,
+        IReadOnlyList<SentimentAnalysis> analyses,
+        DateTime midpoint)
+    {
+        var current  = analyses.Where(a => a.AnalyzedAt >= midpoint).ToList();
+        var previous = analyses.Where(a => a.AnalyzedAt <  midpoint).ToList();
+
+        var currentAvg  = current.Count  > 0 ? current.Average(a => a.Score.Value)  : 0.0;
+        var previousAvg = previous.Count > 0 ? previous.Average(a => a.Score.Value) : 0.0;
+
+        var delta = Math.Round(currentAvg - previousAvg, 4);
+        currentAvg  = Math.Round(currentAvg,  4);
+        previousAvg = Math.Round(previousAvg, 4);
+
+        var direction = delta switch
+        {
+            > 0  => "up",
+            < 0  => "down",
+            _    => "flat"
+        };
+
+        return new TrendingSymbolDto(symbol, currentAvg, previousAvg, delta, direction);
+    }
+}

--- a/Application/Features/Sentiment/Queries/GetTrendingSymbols/TrendingSymbolDto.cs
+++ b/Application/Features/Sentiment/Queries/GetTrendingSymbols/TrendingSymbolDto.cs
@@ -1,0 +1,8 @@
+namespace Application.Features.Sentiment.Queries.GetTrendingSymbols;
+
+public record TrendingSymbolDto(
+    string Symbol,
+    double CurrentAvgScore,
+    double PreviousAvgScore,
+    double Delta,
+    string Direction);

--- a/Domain/Interfaces/ISentimentRepository.cs
+++ b/Domain/Interfaces/ISentimentRepository.cs
@@ -24,4 +24,8 @@ public interface ISentimentRepository
         StockSymbol symbol,
         int days,
         CancellationToken ct = default);
+
+    Task<IReadOnlyList<SentimentAnalysis>> GetRecentAsync(
+        DateTime from,
+        CancellationToken ct = default);
 }

--- a/Infrastructure/Persistence/Repositories/SentimentRepository.cs
+++ b/Infrastructure/Persistence/Repositories/SentimentRepository.cs
@@ -53,4 +53,15 @@ public class SentimentRepository(AppDbContext context) : ISentimentRepository
             .OrderBy(a => a.AnalyzedAt)
             .ToListAsync(ct);
     }
+
+    public async Task<IReadOnlyList<SentimentAnalysis>> GetRecentAsync(
+        DateTime from,
+        CancellationToken ct = default)
+    {
+        return await context.SentimentAnalyses
+            .Where(a => a.AnalyzedAt >= from)
+            .OrderBy(a => a.Symbol)
+            .ThenBy(a => a.AnalyzedAt)
+            .ToListAsync(ct);
+    }
 }

--- a/Tests/Application/GetTrendingSymbolsHandlerTests.cs
+++ b/Tests/Application/GetTrendingSymbolsHandlerTests.cs
@@ -1,0 +1,177 @@
+using Application.Features.Sentiment.Queries.GetTrendingSymbols;
+using Domain.Entities;
+using Domain.Interfaces;
+using Domain.ValueObjects;
+using FluentAssertions;
+using NSubstitute;
+
+namespace Tests.Application;
+
+public class GetTrendingSymbolsHandlerTests
+{
+    private readonly ISentimentRepository _repository = Substitute.For<ISentimentRepository>();
+
+    private GetTrendingSymbolsQueryHandler CreateHandler() => new(_repository);
+
+    /// <summary>
+    /// Creates a SentimentAnalysis and back-dates its AnalyzedAt via reflection
+    /// so handler window-split logic can be tested without a clock abstraction.
+    /// </summary>
+    private static SentimentAnalysis MakeAnalysis(string symbol, double score, DateTime analyzedAt)
+    {
+        var analysis = SentimentAnalysis.Create(
+            new StockSymbol(symbol),
+            "Test headline text.",
+            null,
+            score,
+            0.9,
+            [],
+            "test-model");
+
+        typeof(SentimentAnalysis)
+            .GetProperty(nameof(SentimentAnalysis.AnalyzedAt))!
+            .SetValue(analysis, analyzedAt);
+
+        return analysis;
+    }
+
+    [Fact]
+    public async Task Handle_NoData_ReturnsEmptyList()
+    {
+        _repository.GetRecentAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        var result = await CreateHandler().Handle(new GetTrendingSymbolsQuery(24, 10), CancellationToken.None);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_SingleDataPoint_ReturnsSymbolWithPreviousAvgZero()
+    {
+        var now = DateTime.UtcNow;
+        // Place the single point in the current half (within last 12h)
+        var analysis = MakeAnalysis("AAPL", 0.8, now.AddHours(-6));
+
+        _repository.GetRecentAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns([analysis]);
+
+        var result = await CreateHandler().Handle(new GetTrendingSymbolsQuery(24, 10), CancellationToken.None);
+
+        result.Should().HaveCount(1);
+        result[0].Symbol.Should().Be("AAPL");
+        result[0].CurrentAvgScore.Should().Be(0.8);
+        result[0].PreviousAvgScore.Should().Be(0.0);
+        result[0].Delta.Should().Be(0.8);
+        result[0].Direction.Should().Be("up");
+    }
+
+    [Fact]
+    public async Task Handle_PositiveShift_ReturnsDirectionUp()
+    {
+        var now = DateTime.UtcNow;
+        var previous = MakeAnalysis("TSLA", -0.4, now.AddHours(-20));
+        var current  = MakeAnalysis("TSLA",  0.6, now.AddHours(-2));
+
+        _repository.GetRecentAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns([previous, current]);
+
+        var result = await CreateHandler().Handle(new GetTrendingSymbolsQuery(24, 10), CancellationToken.None);
+
+        result.Should().HaveCount(1);
+        result[0].Direction.Should().Be("up");
+        result[0].Delta.Should().BeApproximately(1.0, 0.001);
+    }
+
+    [Fact]
+    public async Task Handle_NegativeShift_ReturnsDirectionDown()
+    {
+        var now = DateTime.UtcNow;
+        var previous = MakeAnalysis("MSFT", 0.6, now.AddHours(-20));
+        var current  = MakeAnalysis("MSFT", -0.4, now.AddHours(-2));
+
+        _repository.GetRecentAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns([previous, current]);
+
+        var result = await CreateHandler().Handle(new GetTrendingSymbolsQuery(24, 10), CancellationToken.None);
+
+        result.Should().HaveCount(1);
+        result[0].Direction.Should().Be("down");
+        result[0].Delta.Should().BeApproximately(-1.0, 0.001);
+    }
+
+    [Fact]
+    public async Task Handle_AllSymbolsEqualShift_ReturnsFlatDirection()
+    {
+        var now = DateTime.UtcNow;
+        var a1 = MakeAnalysis("AMZN", 0.5, now.AddHours(-20));
+        var a2 = MakeAnalysis("AMZN", 0.5, now.AddHours(-2));
+
+        _repository.GetRecentAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns([a1, a2]);
+
+        var result = await CreateHandler().Handle(new GetTrendingSymbolsQuery(24, 10), CancellationToken.None);
+
+        result.Should().HaveCount(1);
+        result[0].Direction.Should().Be("flat");
+        result[0].Delta.Should().Be(0.0);
+    }
+
+    [Fact]
+    public async Task Handle_MultipleSymbols_OrderedByAbsoluteDeltaDescending()
+    {
+        var now = DateTime.UtcNow;
+
+        // AAPL: small shift (delta = 0.1)
+        var aaplPrev    = MakeAnalysis("AAPL", 0.4, now.AddHours(-20));
+        var aaplCurrent = MakeAnalysis("AAPL", 0.5, now.AddHours(-2));
+
+        // TSLA: large shift (delta = 0.9)
+        var tslaPrev    = MakeAnalysis("TSLA", -0.4, now.AddHours(-20));
+        var tslaCurrent = MakeAnalysis("TSLA",  0.5, now.AddHours(-2));
+
+        _repository.GetRecentAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns([aaplPrev, aaplCurrent, tslaPrev, tslaCurrent]);
+
+        var result = await CreateHandler().Handle(new GetTrendingSymbolsQuery(24, 10), CancellationToken.None);
+
+        result.Should().HaveCount(2);
+        result[0].Symbol.Should().Be("TSLA");
+        result[1].Symbol.Should().Be("AAPL");
+    }
+
+    [Fact]
+    public async Task Handle_LimitEnforced_ReturnsOnlyTopN()
+    {
+        var now = DateTime.UtcNow;
+        var analyses = Enumerable.Range(1, 15)
+            .SelectMany(i => new[]
+            {
+                MakeAnalysis($"SYM{i:D2}", -0.5, now.AddHours(-20)),
+                MakeAnalysis($"SYM{i:D2}",  0.5, now.AddHours(-2))
+            })
+            .ToList();
+
+        _repository.GetRecentAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(analyses);
+
+        var result = await CreateHandler().Handle(new GetTrendingSymbolsQuery(24, 5), CancellationToken.None);
+
+        result.Should().HaveCount(5);
+    }
+
+    [Fact]
+    public async Task Handle_QueriesCorrectWindowFromRepository()
+    {
+        _repository.GetRecentAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        var before = DateTime.UtcNow.AddHours(-24);
+        await CreateHandler().Handle(new GetTrendingSymbolsQuery(24, 10), CancellationToken.None);
+        var after = DateTime.UtcNow.AddHours(-24);
+
+        await _repository.Received(1).GetRecentAsync(
+            Arg.Is<DateTime>(d => d >= before && d <= after),
+            Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `GET /api/sentiment/trending?hours=24&limit=10` endpoint returning the top symbols by largest sentiment score shift over a rolling window
- Response includes `symbol`, `currentAvgScore`, `previousAvgScore`, `delta`, and `direction` (`up`/`down`/`flat`)
- Splits the `hours` window into two equal halves; computes average score per half per symbol; ranks by `|delta|` descending
- Repository query targets `IX_SentimentAnalyses_Symbol_AnalyzedAt` via ordered EF Core predicate on `AnalyzedAt >= from`

## Changes

| Layer | File | Change |
|-------|------|--------|
| Domain | `ISentimentRepository` | `GetRecentAsync(DateTime from)` |
| Application | `GetTrendingSymbolsQuery` | new CQRS query record |
| Application | `GetTrendingSymbolsQueryHandler` | window-split delta computation |
| Application | `TrendingSymbolDto` | response DTO record |
| Infrastructure | `SentimentRepository` | `GetRecentAsync` implementation |
| API | `SentimentController` | `GET /api/sentiment/trending` action |
| Tests | `GetTrendingSymbolsHandlerTests` | 8 unit tests |

## Test plan

- [x] `Handle_NoData_ReturnsEmptyList`
- [x] `Handle_SingleDataPoint_ReturnsSymbolWithPreviousAvgZero`
- [x] `Handle_PositiveShift_ReturnsDirectionUp`
- [x] `Handle_NegativeShift_ReturnsDirectionDown`
- [x] `Handle_AllSymbolsEqualShift_ReturnsFlatDirection`
- [x] `Handle_MultipleSymbols_OrderedByAbsoluteDeltaDescending`
- [x] `Handle_LimitEnforced_ReturnsOnlyTopN`
- [x] `Handle_QueriesCorrectWindowFromRepository`
- [x] All 50 tests pass (`dotnet test Tests/Tests.csproj`)

Closes #4