### PR TITLE
Add GHCR release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,7 @@ jobs:
           dotnet-version: '10.0.x'
 
       - name: Run tests
-        run: dotnet test Tests/Tests.csproj --configuration Release --no-build --verbosity normal
-        # Note: appsettings.Testing.json must be present; secrets are injected via env
+        run: dotnet test Tests/Tests.csproj --configuration Release --verbosity normal
         env:
           ASPNETCORE_ENVIRONMENT: Testing
 


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow that builds and pushes Docker image to GHCR
- Triggers on push to `main` (tags as `latest`) and on GitHub Release (tags with version + `latest`)
- Runs test suite before building — fails fast if tests break
- Uses Docker Buildx with registry cache for faster builds

## Deployment to TrueNAS
After merge, create a GitHub Release (e.g. `v1.0.0`) to push a tagged image. Then on TrueNAS:
```bash
docker pull ghcr.io/abhishekmandhare/financial-sentiment-api:v1.0.0
```

## Test plan
- [x] Workflow syntax validated
- [x] Fixed `--no-build` bug from original agent PR (tests need compilation)
- [ ] Verify workflow runs on next push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)