### PR TITLE
ci: add Docker image vulnerability scan with Trivy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,3 +80,19 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Scan image for vulnerabilities
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.IMAGE_NAME }}:latest
+          format: table
+          output: trivy-results.txt
+          exit-code: 1
+          severity: CRITICAL,HIGH
+
+      - name: Upload Trivy scan results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: trivy-scan-results
+          path: trivy-results.txt


### PR DESCRIPTION
## Summary

- Adds a Trivy scan step to `release.yml` after the Docker image is built and pushed to GHCR
- Fails the workflow (`exit-code: 1`) on any CRITICAL or HIGH severity CVEs in OS packages or .NET dependencies
- Uploads the scan results table as a downloadable workflow artifact (`trivy-scan-results`) — available even when the scan fails (`if: always()`)

## Test plan

- [x] Merge triggers `build-and-push` job; Trivy step runs after image is pushed to GHCR
- [ ] If CRITICAL/HIGH CVEs are found, the workflow fails and the results file is still uploaded as an artifact
- [ ] If no CVEs at or above threshold, workflow passes and artifact contains the clean table
- [ ] Artifact is visible under the workflow run's "Artifacts" section

Closes #23