### PR TITLE
Add 30-day sentiment trend chart to dashboard (#46)

### DIFF
--- a/API/wwwroot/index.html
+++ b/API/wwwroot/index.html
@@ -250,6 +250,34 @@
         .distribution-bar .neu { background: var(--yellow); }
         .distribution-bar .neg { background: var(--red); }
 
+        /* Trend Chart */
+        .trend-chart-section {
+            padding: 20px;
+            border-top: 1px solid var(--border);
+        }
+
+        .trend-chart-section .section-title {
+            margin-bottom: 8px;
+        }
+
+        .trend-chart-container {
+            width: 100%;
+            overflow: hidden;
+        }
+
+        .trend-chart-container svg {
+            width: 100%;
+            height: auto;
+            display: block;
+        }
+
+        .trend-chart-empty {
+            color: var(--text-dim);
+            font-size: 0.85rem;
+            padding: 24px 0;
+            text-align: center;
+        }
+
         .history-list {
             padding: 16px 20px;
         }
@@ -328,6 +356,7 @@
             .stats-grid { grid-template-columns: repeat(2, 1fr); }
             .sparkline-cell { display: none; }
             th.sparkline-header { display: none; }
+            .trend-chart-section { padding: 12px; }
         }
     </style>
 </head>
@@ -350,6 +379,10 @@
                 <button class="close-btn" onclick="closeDetail()">Close</button>
             </div>
             <div class="stats-grid" id="statsGrid"></div>
+            <div class="trend-chart-section" id="trendChartSection" style="display:none;">
+                <p class="section-title">30-Day Sentiment Trend</p>
+                <div class="trend-chart-container" id="trendChartContainer"></div>
+            </div>
             <div class="history-list" id="historyList"></div>
         </div>
 
@@ -485,6 +518,97 @@
             </svg>`;
         }
 
+        // -- Trend Chart --------------------------------------------------
+
+        function createTrendChart(dataPoints) {
+            if (!dataPoints || dataPoints.length < 2) {
+                return '<div class="trend-chart-empty">Not enough data for trend chart</div>';
+            }
+
+            // Sort by date ascending
+            const sorted = [...dataPoints].sort((a, b) => new Date(a.date) - new Date(b.date));
+
+            const width = 700;
+            const height = 220;
+            const padTop = 20;
+            const padBottom = 40;
+            const padLeft = 45;
+            const padRight = 15;
+            const chartW = width - padLeft - padRight;
+            const chartH = height - padTop - padBottom;
+
+            const scores = sorted.map(d => d.score);
+            const dates = sorted.map(d => new Date(d.date));
+
+            // Y-axis: always show -1 to +1 range for sentiment
+            const yMin = -1;
+            const yMax = 1;
+            const yRange = yMax - yMin;
+
+            // Determine trend direction from first to last score
+            const firstScore = scores[0];
+            const lastScore = scores[scores.length - 1];
+            const isPositiveTrend = lastScore >= firstScore;
+            const lineColor = isPositiveTrend ? '#00c48c' : '#ff5c5c';
+
+            const gradientId = 'tg' + Math.random().toString(36).substring(2, 8);
+
+            // Map data to SVG coordinates
+            const points = sorted.map((d, i) => {
+                const x = padLeft + (i / (sorted.length - 1)) * chartW;
+                const y = padTop + (1 - (d.score - yMin) / yRange) * chartH;
+                return { x, y };
+            });
+
+            const polyline = points.map(p => `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' ');
+
+            // Fill polygon (area under line to zero line)
+            const zeroY = padTop + (1 - (0 - yMin) / yRange) * chartH;
+            const fillPoints = points.map(p => `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' ')
+                + ` ${points[points.length - 1].x.toFixed(1)},${zeroY.toFixed(1)}`
+                + ` ${points[0].x.toFixed(1)},${zeroY.toFixed(1)}`;
+
+            // Y-axis labels
+            const yTicks = [-1, -0.5, 0, 0.5, 1];
+            const yLabels = yTicks.map(v => {
+                const y = padTop + (1 - (v - yMin) / yRange) * chartH;
+                return `<text x="${padLeft - 8}" y="${y.toFixed(1)}" text-anchor="end" dominant-baseline="middle" fill="#8b8fa3" font-size="10">${v.toFixed(1)}</text>
+                        <line x1="${padLeft}" y1="${y.toFixed(1)}" x2="${width - padRight}" y2="${y.toFixed(1)}" stroke="#2e3345" stroke-width="0.5" ${v === 0 ? 'stroke-dasharray="4,3" stroke-width="1" stroke="#5b8def" opacity="0.5"' : ''}/>`;
+            }).join('\n');
+
+            // X-axis labels — show a few evenly spaced dates
+            const isMobile = typeof window !== 'undefined' && window.innerWidth < 600;
+            const labelCount = isMobile ? 3 : Math.min(6, sorted.length);
+            const xLabels = [];
+            for (let i = 0; i < labelCount; i++) {
+                const idx = Math.round(i * (sorted.length - 1) / (labelCount - 1));
+                const x = padLeft + (idx / (sorted.length - 1)) * chartW;
+                const d = dates[idx];
+                const label = d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+                xLabels.push(`<text x="${x.toFixed(1)}" y="${height - 8}" text-anchor="middle" fill="#8b8fa3" font-size="10">${label}</text>`);
+            }
+
+            // Data point dots — show a subset to avoid clutter
+            const dotInterval = Math.max(1, Math.floor(sorted.length / 15));
+            const dots = points
+                .filter((_, i) => i % dotInterval === 0 || i === points.length - 1)
+                .map(p => `<circle cx="${p.x.toFixed(1)}" cy="${p.y.toFixed(1)}" r="2.5" fill="${lineColor}" stroke="#1a1d27" stroke-width="1"/>`);
+
+            return `<svg viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" style="max-height:280px;">
+                <defs>
+                    <linearGradient id="${gradientId}" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="0%" stop-color="${lineColor}" stop-opacity="0.20"/>
+                        <stop offset="100%" stop-color="${lineColor}" stop-opacity="0.02"/>
+                    </linearGradient>
+                </defs>
+                ${yLabels}
+                ${xLabels.join('\n')}
+                <polygon points="${fillPoints}" fill="url(#${gradientId})"/>
+                <polyline points="${polyline}" fill="none" stroke="${lineColor}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                ${dots.join('\n')}
+            </svg>`;
+        }
+
         // -- Trending -----------------------------------------------------
 
         async function loadTrending() {
@@ -559,17 +683,29 @@
             const panel = document.getElementById('detailPanel');
             document.getElementById('detailSymbol').innerHTML = `${symbol} <span style="font-size:0.85rem;color:var(--text-dim);font-weight:normal;margin-left:8px">${symbolName(symbol)}</span>`;
             document.getElementById('statsGrid').innerHTML = '<div class="stat-cell"><span class="stat-label">Loading...</span></div>';
+            document.getElementById('trendChartSection').style.display = 'none';
+            document.getElementById('trendChartContainer').innerHTML = '';
             document.getElementById('historyList').innerHTML = '';
             panel.classList.add('visible');
             panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
 
-            const [stats, history] = await Promise.allSettled([
+            const [stats, history, trendHistory] = await Promise.allSettled([
                 fetch(`${API}/api/sentiment/${symbol}/stats?days=30`).then(r => r.ok ? r.json() : null),
-                fetch(`${API}/api/sentiment/${symbol}/history?page=1&pageSize=15`).then(r => r.ok ? r.json() : null)
+                fetch(`${API}/api/sentiment/${symbol}/history?page=1&pageSize=15`).then(r => r.ok ? r.json() : null),
+                fetch(`${API}/api/sentiment/${symbol}/history?page=1&pageSize=100`).then(r => r.ok ? r.json() : null)
             ]);
 
             if (stats.status === 'fulfilled' && stats.value) renderStats(stats.value);
             else document.getElementById('statsGrid').innerHTML = '<div class="stat-cell"><span class="stat-label">No stats available</span></div>';
+
+            // Render 30-day trend chart
+            if (trendHistory.status === 'fulfilled' && trendHistory.value && trendHistory.value.items) {
+                const chartData = trendHistory.value.items.map(h => ({ date: h.analyzedAt, score: h.score }));
+                const section = document.getElementById('trendChartSection');
+                const container = document.getElementById('trendChartContainer');
+                container.innerHTML = createTrendChart(chartData);
+                section.style.display = 'block';
+            }
 
             if (history.status === 'fulfilled' && history.value) renderHistory(history.value.items);
             else document.getElementById('historyList').innerHTML = '<p style="color:var(--text-dim);font-size:0.85rem;">No history available</p>';


### PR DESCRIPTION
## Summary
- Adds a 30-day sentiment trend line chart (pure SVG) to the symbol detail panel
- Chart shows sentiment score (-1 to +1) over time with green/red trend coloring, gradient fill, and a dashed zero-line boundary
- Responsive design: simplifies date labels on mobile
- No external charting libraries — pure SVG like existing sparklines

Closes #46

## Test plan
- [ ] Click a symbol row to open the detail panel
- [ ] Verify the "30-Day Sentiment Trend" chart renders between stats and history
- [ ] Confirm green line for positive trend, red for negative
- [ ] Confirm zero-line (dashed blue) is visible at y=0
- [ ] Resize to mobile width and verify chart adapts
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 81 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)