### PR TITLE
feat: show source article links in history panel (#32)

### DIFF
--- a/API/wwwroot/index.html
+++ b/API/wwwroot/index.html
@@ -280,6 +280,20 @@
             margin-top: 2px;
         }
 
+        .history-source {
+            font-size: 0.75rem;
+            margin-top: 3px;
+        }
+
+        .history-source a {
+            color: var(--blue);
+            text-decoration: none;
+        }
+
+        .history-source a:hover {
+            text-decoration: underline;
+        }
+
         .confidence-bar {
             display: inline-block;
             width: 40px;
@@ -645,6 +659,7 @@
                             <span class="history-time">${formatDate(h.analyzedAt)}</span>
                         </div>
                         ${h.keyReasons && h.keyReasons.length ? `<div class="history-reasons">${h.keyReasons.join(' &middot; ')}</div>` : ''}
+                        ${h.sourceUrl ? `<div class="history-source"><a href="${escapeHtml(h.sourceUrl)}" target="_blank" rel="noopener noreferrer">${extractDomain(h.sourceUrl)}</a></div>` : ''}
                     </div>`;
                 }).join('');
         }
@@ -674,6 +689,21 @@
 
         function hideError() {
             document.getElementById('errorBanner').classList.remove('visible');
+        }
+
+        function extractDomain(url) {
+            try {
+                const hostname = new URL(url).hostname.replace(/^www\./, '');
+                return hostname;
+            } catch {
+                return 'Source';
+            }
+        }
+
+        function escapeHtml(str) {
+            const div = document.createElement('div');
+            div.appendChild(document.createTextNode(str));
+            return div.innerHTML;
         }
 
         function formatDate(iso) {


### PR DESCRIPTION
## Summary
- Display `sourceUrl` as a clickable link in the detail panel's history list
- Shows extracted domain name (e.g. "reuters.com") as link text
- Opens in new tab with `target="_blank"` and `rel="noopener noreferrer"`
- Gracefully hidden when `sourceUrl` is null/empty
- URL sanitized via `escapeHtml()` to prevent XSS

Closes #32

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 81 tests pass
- [ ] Open detail panel, verify source links appear for entries with sourceUrl
- [ ] Verify entries without sourceUrl show no link
- [ ] Verify links open in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)