### PR TITLE
test: increase unit test coverage to pass 40% threshold

### DIFF
--- a/Tests/Application/GetSentimentHistoryHandlerTests.cs
+++ b/Tests/Application/GetSentimentHistoryHandlerTests.cs
@@ -1,0 +1,150 @@
+using Application.Common.Models;
+using Application.Features.Sentiment.Queries.GetSentimentHistory;
+using Domain.Entities;
+using Domain.Interfaces;
+using Domain.ValueObjects;
+using FluentAssertions;
+using NSubstitute;
+
+namespace Tests.Application;
+
+public class GetSentimentHistoryHandlerTests
+{
+    private readonly ISentimentRepository _repository = Substitute.For<ISentimentRepository>();
+
+    private GetSentimentHistoryQueryHandler CreateHandler() => new(_repository);
+
+    private static SentimentAnalysis CreateAnalysis(double score = 0.5) =>
+        SentimentAnalysis.Create(
+            new StockSymbol("AAPL"),
+            "Apple reported strong earnings.",
+            "https://example.com/article",
+            score,
+            0.85,
+            ["Strong revenue"],
+            "test-model-v1");
+
+    [Fact]
+    public async Task Handle_ReturnsPagedResult_WithCorrectMapping()
+    {
+        var analysis = CreateAnalysis(0.75);
+        var items = new List<SentimentAnalysis> { analysis };
+
+        _repository.GetHistoryAsync(
+                Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<int>(),
+                Arg.Any<DateTime?>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns((items.AsReadOnly() as IReadOnlyList<SentimentAnalysis>, 1));
+
+        var query = new GetSentimentHistoryQuery("AAPL");
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        result.Items.Should().HaveCount(1);
+        result.TotalCount.Should().Be(1);
+        result.Page.Should().Be(1);
+        result.PageSize.Should().Be(20);
+
+        var dto = result.Items[0];
+        dto.Score.Should().Be(0.75);
+        dto.Label.Should().Be("Positive");
+        dto.Confidence.Should().Be(0.85);
+        dto.KeyReasons.Should().Contain("Strong revenue");
+        dto.ModelVersion.Should().Be("test-model-v1");
+        dto.SourceUrl.Should().Be("https://example.com/article");
+    }
+
+    [Fact]
+    public async Task Handle_EmptyResult_ReturnsEmptyPage()
+    {
+        _repository.GetHistoryAsync(
+                Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<int>(),
+                Arg.Any<DateTime?>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns((Array.Empty<SentimentAnalysis>() as IReadOnlyList<SentimentAnalysis>, 0));
+
+        var query = new GetSentimentHistoryQuery("MSFT");
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        result.Items.Should().BeEmpty();
+        result.TotalCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_PassesSymbolToRepository()
+    {
+        _repository.GetHistoryAsync(
+                Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<int>(),
+                Arg.Any<DateTime?>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns((Array.Empty<SentimentAnalysis>() as IReadOnlyList<SentimentAnalysis>, 0));
+
+        var query = new GetSentimentHistoryQuery("aapl");
+        await CreateHandler().Handle(query, CancellationToken.None);
+
+        await _repository.Received(1).GetHistoryAsync(
+            Arg.Is<StockSymbol>(s => s.Value == "AAPL"),
+            Arg.Any<int>(), Arg.Any<int>(),
+            Arg.Any<DateTime?>(), Arg.Any<DateTime?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_PassesPaginationParameters()
+    {
+        _repository.GetHistoryAsync(
+                Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<int>(),
+                Arg.Any<DateTime?>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns((Array.Empty<SentimentAnalysis>() as IReadOnlyList<SentimentAnalysis>, 0));
+
+        var query = new GetSentimentHistoryQuery("AAPL", Page: 3, PageSize: 10);
+        await CreateHandler().Handle(query, CancellationToken.None);
+
+        await _repository.Received(1).GetHistoryAsync(
+            Arg.Any<StockSymbol>(),
+            3, 10,
+            Arg.Any<DateTime?>(), Arg.Any<DateTime?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_PassesDateFilters()
+    {
+        var from = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var to = new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        _repository.GetHistoryAsync(
+                Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<int>(),
+                Arg.Any<DateTime?>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns((Array.Empty<SentimentAnalysis>() as IReadOnlyList<SentimentAnalysis>, 0));
+
+        var query = new GetSentimentHistoryQuery("AAPL", From: from, To: to);
+        await CreateHandler().Handle(query, CancellationToken.None);
+
+        await _repository.Received(1).GetHistoryAsync(
+            Arg.Any<StockSymbol>(),
+            Arg.Any<int>(), Arg.Any<int>(),
+            from, to,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_MultipleItems_MapsAllCorrectly()
+    {
+        var analyses = new List<SentimentAnalysis>
+        {
+            CreateAnalysis(0.8),
+            CreateAnalysis(-0.5),
+            CreateAnalysis(0.0)
+        };
+
+        _repository.GetHistoryAsync(
+                Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<int>(),
+                Arg.Any<DateTime?>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns((analyses.AsReadOnly() as IReadOnlyList<SentimentAnalysis>, 3));
+
+        var query = new GetSentimentHistoryQuery("AAPL");
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        result.Items.Should().HaveCount(3);
+        result.Items[0].Label.Should().Be("Positive");
+        result.Items[1].Label.Should().Be("Negative");
+        result.Items[2].Label.Should().Be("Neutral");
+    }
+}

--- a/Tests/Application/GetSentimentStatsHandlerTests.cs
+++ b/Tests/Application/GetSentimentStatsHandlerTests.cs
@@ -1,0 +1,160 @@
+using Application.Exceptions;
+using Application.Features.Sentiment.Queries.GetSentimentStats;
+using Domain.Entities;
+using Domain.Interfaces;
+using Domain.ValueObjects;
+using FluentAssertions;
+using NSubstitute;
+
+namespace Tests.Application;
+
+public class GetSentimentStatsHandlerTests
+{
+    private readonly ISentimentRepository _repository = Substitute.For<ISentimentRepository>();
+
+    private GetSentimentStatsQueryHandler CreateHandler() => new(_repository);
+
+    private static SentimentAnalysis CreateAnalysis(double score = 0.5) =>
+        SentimentAnalysis.Create(
+            new StockSymbol("AAPL"),
+            "Test article text for analysis.",
+            "https://example.com/article",
+            score,
+            0.85,
+            ["Reason one"],
+            "test-model-v1");
+
+    [Fact]
+    public async Task Handle_NoAnalyses_ThrowsNotFoundException()
+    {
+        _repository.GetForStatsAsync(
+                Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<SentimentAnalysis>() as IReadOnlyList<SentimentAnalysis>);
+
+        var query = new GetSentimentStatsQuery("AAPL", 30);
+        var act = () => CreateHandler().Handle(query, CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_SingleAnalysis_ReturnsCorrectStats()
+    {
+        var analyses = new List<SentimentAnalysis> { CreateAnalysis(0.6) };
+
+        _repository.GetForStatsAsync(
+                Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(analyses.AsReadOnly() as IReadOnlyList<SentimentAnalysis>);
+
+        var query = new GetSentimentStatsQuery("AAPL", 7);
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        result.Symbol.Should().Be("AAPL");
+        result.TotalAnalyses.Should().Be(1);
+        result.AverageScore.Should().Be(0.6);
+        result.AverageConfidence.Should().Be(0.85);
+        result.Distribution.PositivePercent.Should().Be(100.0);
+        result.Distribution.NeutralPercent.Should().Be(0.0);
+        result.Distribution.NegativePercent.Should().Be(0.0);
+        result.LatestScore.Should().Be(0.6);
+        result.Trend.Direction.Should().Be("Stable");
+        result.Trend.Slope.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_MixedSentiments_CalculatesDistribution()
+    {
+        var analyses = new List<SentimentAnalysis>
+        {
+            CreateAnalysis(0.8),   // Positive
+            CreateAnalysis(0.5),   // Positive
+            CreateAnalysis(0.0),   // Neutral
+            CreateAnalysis(-0.5),  // Negative
+        };
+
+        _repository.GetForStatsAsync(
+                Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(analyses.AsReadOnly() as IReadOnlyList<SentimentAnalysis>);
+
+        var query = new GetSentimentStatsQuery("AAPL");
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        result.TotalAnalyses.Should().Be(4);
+        result.Distribution.PositivePercent.Should().Be(50.0);
+        result.Distribution.NeutralPercent.Should().Be(25.0);
+        result.Distribution.NegativePercent.Should().Be(25.0);
+    }
+
+    [Fact]
+    public async Task Handle_CalculatesHighestAndLowestScores()
+    {
+        var analyses = new List<SentimentAnalysis>
+        {
+            CreateAnalysis(0.9),
+            CreateAnalysis(-0.3),
+            CreateAnalysis(0.1),
+        };
+
+        _repository.GetForStatsAsync(
+                Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(analyses.AsReadOnly() as IReadOnlyList<SentimentAnalysis>);
+
+        var query = new GetSentimentStatsQuery("AAPL");
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        result.HighestScore.Score.Should().Be(0.9);
+        result.LowestScore.Score.Should().Be(-0.3);
+    }
+
+    [Fact]
+    public async Task Handle_CalculatesAverageScore()
+    {
+        var analyses = new List<SentimentAnalysis>
+        {
+            CreateAnalysis(0.8),
+            CreateAnalysis(0.2),
+        };
+
+        _repository.GetForStatsAsync(
+                Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(analyses.AsReadOnly() as IReadOnlyList<SentimentAnalysis>);
+
+        var query = new GetSentimentStatsQuery("AAPL");
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        result.AverageScore.Should().Be(0.5);
+    }
+
+    [Fact]
+    public async Task Handle_PassesCorrectDaysToRepository()
+    {
+        _repository.GetForStatsAsync(
+                Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<SentimentAnalysis>() as IReadOnlyList<SentimentAnalysis>);
+
+        var query = new GetSentimentStatsQuery("MSFT", 14);
+
+        // Will throw NotFoundException since empty, but repository should still be called
+        try { await CreateHandler().Handle(query, CancellationToken.None); } catch { }
+
+        await _repository.Received(1).GetForStatsAsync(
+            Arg.Is<StockSymbol>(s => s.Value == "MSFT"),
+            14,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_Period_ContainsCorrectDays()
+    {
+        var analyses = new List<SentimentAnalysis> { CreateAnalysis(0.5) };
+
+        _repository.GetForStatsAsync(
+                Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(analyses.AsReadOnly() as IReadOnlyList<SentimentAnalysis>);
+
+        var query = new GetSentimentStatsQuery("AAPL", 7);
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        result.Period.Days.Should().Be(7);
+    }
+}

--- a/Tests/Application/LoggingBehaviorTests.cs
+++ b/Tests/Application/LoggingBehaviorTests.cs
@@ -1,0 +1,69 @@
+using Application.Behaviors;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Tests.Application;
+
+public class LoggingBehaviorTests
+{
+    private readonly ILogger<LoggingBehavior<TestRequest, TestResponse>> _logger =
+        Substitute.For<ILogger<LoggingBehavior<TestRequest, TestResponse>>>();
+
+    public record TestRequest : IRequest<TestResponse>;
+    public record TestResponse(string Value);
+
+    private LoggingBehavior<TestRequest, TestResponse> CreateBehavior() => new(_logger);
+
+    [Fact]
+    public async Task Handle_SuccessfulRequest_ReturnsResponse()
+    {
+        var expected = new TestResponse("ok");
+        RequestHandlerDelegate<TestResponse> next = () => Task.FromResult(expected);
+
+        var result = await CreateBehavior().Handle(new TestRequest(), next, CancellationToken.None);
+
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task Handle_FailingRequest_RethrowsException()
+    {
+        RequestHandlerDelegate<TestResponse> next = () => throw new InvalidOperationException("boom");
+
+        var act = () => CreateBehavior().Handle(new TestRequest(), next, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("boom");
+    }
+
+    [Fact]
+    public async Task Handle_SuccessfulRequest_LogsHandlingAndHandled()
+    {
+        RequestHandlerDelegate<TestResponse> next = () => Task.FromResult(new TestResponse("ok"));
+
+        await CreateBehavior().Handle(new TestRequest(), next, CancellationToken.None);
+
+        _logger.Received(1).Log(
+            LogLevel.Information,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o => o.ToString()!.Contains("Handling")),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
+    public async Task Handle_FailingRequest_LogsError()
+    {
+        RequestHandlerDelegate<TestResponse> next = () => throw new InvalidOperationException("boom");
+
+        try { await CreateBehavior().Handle(new TestRequest(), next, CancellationToken.None); } catch { }
+
+        _logger.Received(1).Log(
+            LogLevel.Error,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+}

--- a/Tests/Application/NotFoundExceptionTests.cs
+++ b/Tests/Application/NotFoundExceptionTests.cs
@@ -1,0 +1,24 @@
+using Application.Exceptions;
+using FluentAssertions;
+
+namespace Tests.Application;
+
+public class NotFoundExceptionTests
+{
+    [Fact]
+    public void Constructor_FormatsMessage_WithResourceAndKey()
+    {
+        var ex = new NotFoundException("SentimentAnalysis", "AAPL");
+        ex.Message.Should().Contain("SentimentAnalysis");
+        ex.Message.Should().Contain("AAPL");
+        ex.Message.Should().Contain("not found");
+    }
+
+    [Fact]
+    public void Constructor_WithGuidKey_IncludesKeyInMessage()
+    {
+        var key = Guid.NewGuid();
+        var ex = new NotFoundException("TrackedSymbol", key);
+        ex.Message.Should().Contain(key.ToString());
+    }
+}

--- a/Tests/Application/PagedResultTests.cs
+++ b/Tests/Application/PagedResultTests.cs
@@ -1,0 +1,47 @@
+using Application.Common.Models;
+using FluentAssertions;
+
+namespace Tests.Application;
+
+public class PagedResultTests
+{
+    [Fact]
+    public void TotalPages_ExactDivision_ReturnsCorrectCount()
+    {
+        var result = new PagedResult<string>(["a", "b"], 10, 1, 5);
+        result.TotalPages.Should().Be(2);
+    }
+
+    [Fact]
+    public void TotalPages_PartialPage_RoundsUp()
+    {
+        var result = new PagedResult<string>(["a"], 11, 1, 5);
+        result.TotalPages.Should().Be(3);
+    }
+
+    [Fact]
+    public void TotalPages_SingleItem_ReturnsOne()
+    {
+        var result = new PagedResult<string>(["a"], 1, 1, 20);
+        result.TotalPages.Should().Be(1);
+    }
+
+    [Fact]
+    public void TotalPages_ZeroItems_ReturnsZero()
+    {
+        var result = new PagedResult<string>([], 0, 1, 20);
+        result.TotalPages.Should().Be(0);
+    }
+
+    [Fact]
+    public void Properties_RetainValues()
+    {
+        var items = new List<string> { "item1", "item2" };
+        var result = new PagedResult<string>(items, 50, 3, 10);
+
+        result.Items.Should().BeEquivalentTo(items);
+        result.TotalCount.Should().Be(50);
+        result.Page.Should().Be(3);
+        result.PageSize.Should().Be(10);
+    }
+}

--- a/Tests/Application/ValidationExceptionTests.cs
+++ b/Tests/Application/ValidationExceptionTests.cs
@@ -1,0 +1,40 @@
+using FluentAssertions;
+using FluentValidation.Results;
+using ValidationException = Application.Exceptions.ValidationException;
+
+namespace Tests.Application;
+
+public class ValidationExceptionTests
+{
+    [Fact]
+    public void Constructor_GroupsErrorsByPropertyName()
+    {
+        var failures = new List<ValidationFailure>
+        {
+            new("Symbol", "Symbol is required."),
+            new("Symbol", "Symbol must not exceed 10 chars."),
+            new("Text", "Text is required."),
+        };
+
+        var ex = new ValidationException(failures);
+
+        ex.Errors.Should().ContainKey("Symbol");
+        ex.Errors["Symbol"].Should().HaveCount(2);
+        ex.Errors.Should().ContainKey("Text");
+        ex.Errors["Text"].Should().ContainSingle();
+    }
+
+    [Fact]
+    public void Constructor_EmptyFailures_ProducesEmptyErrors()
+    {
+        var ex = new ValidationException([]);
+        ex.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Message_ContainsValidationText()
+    {
+        var ex = new ValidationException([]);
+        ex.Message.Should().Contain("validation");
+    }
+}

--- a/Tests/Domain/DomainExceptionTests.cs
+++ b/Tests/Domain/DomainExceptionTests.cs
@@ -1,0 +1,31 @@
+using Domain.Exceptions;
+using FluentAssertions;
+
+namespace Tests.Domain;
+
+public class DomainExceptionTests
+{
+    [Fact]
+    public void Constructor_WithMessage_SetsMessage()
+    {
+        var ex = new DomainException("Something went wrong.");
+        ex.Message.Should().Be("Something went wrong.");
+    }
+
+    [Fact]
+    public void Constructor_WithInnerException_SetsInnerException()
+    {
+        var inner = new InvalidOperationException("inner");
+        var ex = new DomainException("outer", inner);
+
+        ex.Message.Should().Be("outer");
+        ex.InnerException.Should().Be(inner);
+    }
+
+    [Fact]
+    public void Constructor_Default_HasDefaultMessage()
+    {
+        var ex = new DomainException();
+        ex.Message.Should().NotBeNullOrEmpty();
+    }
+}

--- a/Tests/Domain/SentimentAnalysisEdgeCaseTests.cs
+++ b/Tests/Domain/SentimentAnalysisEdgeCaseTests.cs
@@ -1,0 +1,105 @@
+using Domain.Entities;
+using Domain.Enums;
+using Domain.Exceptions;
+using Domain.ValueObjects;
+using FluentAssertions;
+
+namespace Tests.Domain;
+
+public class SentimentAnalysisEdgeCaseTests
+{
+    private static readonly StockSymbol Symbol = new("AAPL");
+
+    [Fact]
+    public void Create_EmptyModelVersion_ThrowsDomainException()
+    {
+        var act = () => SentimentAnalysis.Create(Symbol, "Valid text.", null, 0.5, 0.9, [], "");
+        act.Should().Throw<DomainException>().WithMessage("*Model version*");
+    }
+
+    [Fact]
+    public void Create_WhitespaceModelVersion_ThrowsDomainException()
+    {
+        var act = () => SentimentAnalysis.Create(Symbol, "Valid text.", null, 0.5, 0.9, [], "   ");
+        act.Should().Throw<DomainException>().WithMessage("*Model version*");
+    }
+
+    [Fact]
+    public void Create_ConfidenceExactlyZero_Succeeds()
+    {
+        var analysis = SentimentAnalysis.Create(Symbol, "Valid text.", null, 0.5, 0.0, [], "model-v1");
+        analysis.Confidence.Should().Be(0.0);
+    }
+
+    [Fact]
+    public void Create_ConfidenceExactlyOne_Succeeds()
+    {
+        var analysis = SentimentAnalysis.Create(Symbol, "Valid text.", null, 0.5, 1.0, [], "model-v1");
+        analysis.Confidence.Should().Be(1.0);
+    }
+
+    [Fact]
+    public void Create_NullSourceUrl_StoresNull()
+    {
+        var analysis = SentimentAnalysis.Create(Symbol, "Valid text.", null, 0.5, 0.9, [], "model-v1");
+        analysis.SourceUrl.Should().BeNull();
+    }
+
+    [Fact]
+    public void Create_WithSourceUrl_StoresUrl()
+    {
+        var analysis = SentimentAnalysis.Create(
+            Symbol, "Valid text.", "https://example.com", 0.5, 0.9, [], "model-v1");
+        analysis.SourceUrl.Should().Be("https://example.com");
+    }
+
+    [Fact]
+    public void Create_EmptyKeyReasons_AcceptsEmptyList()
+    {
+        var analysis = SentimentAnalysis.Create(Symbol, "Valid text.", null, 0.5, 0.9, [], "model-v1");
+        analysis.KeyReasons.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Create_TextExactly5000Chars_Succeeds()
+    {
+        var text = new string('x', 5000);
+        var analysis = SentimentAnalysis.Create(Symbol, text, null, 0.5, 0.9, [], "model-v1");
+        analysis.OriginalText.Should().HaveLength(5000);
+    }
+
+    [Theory]
+    [InlineData(-1.0, SentimentLabel.Negative)]
+    [InlineData(-0.21, SentimentLabel.Negative)]
+    [InlineData(-0.2, SentimentLabel.Neutral)]
+    [InlineData(0.0, SentimentLabel.Neutral)]
+    [InlineData(0.2, SentimentLabel.Neutral)]
+    [InlineData(0.21, SentimentLabel.Positive)]
+    [InlineData(1.0, SentimentLabel.Positive)]
+    public void Create_ScoreBoundaries_DerivesCorrectLabel(double score, SentimentLabel expected)
+    {
+        var analysis = SentimentAnalysis.Create(Symbol, "Valid text.", null, score, 0.9, [], "model-v1");
+        analysis.Label.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Create_WhitespaceText_ThrowsDomainException()
+    {
+        var act = () => SentimentAnalysis.Create(Symbol, "   ", null, 0.5, 0.9, [], "model-v1");
+        act.Should().Throw<DomainException>().WithMessage("*cannot be empty*");
+    }
+
+    [Fact]
+    public void Create_ScoreAtBoundaryNegativeOne_Succeeds()
+    {
+        var analysis = SentimentAnalysis.Create(Symbol, "Valid text.", null, -1.0, 0.9, [], "model-v1");
+        analysis.Score.Value.Should().Be(-1.0);
+    }
+
+    [Fact]
+    public void Create_ScoreAtBoundaryPositiveOne_Succeeds()
+    {
+        var analysis = SentimentAnalysis.Create(Symbol, "Valid text.", null, 1.0, 0.9, [], "model-v1");
+        analysis.Score.Value.Should().Be(1.0);
+    }
+}

--- a/Tests/Domain/TrackedSymbolTests.cs
+++ b/Tests/Domain/TrackedSymbolTests.cs
@@ -1,0 +1,61 @@
+using Domain.Entities;
+using Domain.Exceptions;
+using FluentAssertions;
+
+namespace Tests.Domain;
+
+public class TrackedSymbolTests
+{
+    [Fact]
+    public void Create_ValidSymbol_ReturnsEntity()
+    {
+        var symbol = TrackedSymbol.Create("AAPL");
+
+        symbol.Symbol.Should().Be("AAPL");
+        symbol.Id.Should().NotBe(Guid.Empty);
+        symbol.AddedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public void Create_LowercaseSymbol_NormalisesToUppercase()
+    {
+        var symbol = TrackedSymbol.Create("msft");
+        symbol.Symbol.Should().Be("MSFT");
+    }
+
+    [Fact]
+    public void Create_EmptySymbol_ThrowsDomainException()
+    {
+        var act = () => TrackedSymbol.Create("");
+        act.Should().Throw<DomainException>().WithMessage("*cannot be empty*");
+    }
+
+    [Fact]
+    public void Create_WhitespaceSymbol_ThrowsDomainException()
+    {
+        var act = () => TrackedSymbol.Create("   ");
+        act.Should().Throw<DomainException>().WithMessage("*cannot be empty*");
+    }
+
+    [Fact]
+    public void Create_SymbolExceeds10Chars_ThrowsDomainException()
+    {
+        var act = () => TrackedSymbol.Create("TOOLONGSYMBOL");
+        act.Should().Throw<DomainException>().WithMessage("*10 characters*");
+    }
+
+    [Fact]
+    public void Create_ExactlyTenChars_Succeeds()
+    {
+        var symbol = TrackedSymbol.Create("ABCDEFGHIJ");
+        symbol.Symbol.Should().Be("ABCDEFGHIJ");
+    }
+
+    [Fact]
+    public void Create_GeneratesUniqueIds()
+    {
+        var a = TrackedSymbol.Create("AAPL");
+        var b = TrackedSymbol.Create("AAPL");
+        a.Id.Should().NotBe(b.Id);
+    }
+}

--- a/Tests/Infrastructure/InMemoryArticleQueueTests.cs
+++ b/Tests/Infrastructure/InMemoryArticleQueueTests.cs
@@ -1,0 +1,75 @@
+using Application.Services;
+using FluentAssertions;
+using Infrastructure.Ingestion;
+
+namespace Tests.Infrastructure;
+
+public class InMemoryArticleQueueTests
+{
+    [Fact]
+    public async Task PublishAndConsume_SingleArticle_ReceivesArticle()
+    {
+        var queue = new InMemoryArticleQueue();
+        var article = new ArticleToAnalyze("AAPL", "Apple beat earnings.", "https://example.com", DateTime.UtcNow);
+
+        await queue.PublishAsync(article);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var received = new List<ArticleToAnalyze>();
+
+        await foreach (var item in queue.ConsumeAsync(cts.Token))
+        {
+            received.Add(item);
+            break; // Only expect one
+        }
+
+        received.Should().HaveCount(1);
+        received[0].Symbol.Should().Be("AAPL");
+        received[0].Text.Should().Be("Apple beat earnings.");
+    }
+
+    [Fact]
+    public async Task PublishAndConsume_MultipleArticles_ReceivesAll()
+    {
+        var queue = new InMemoryArticleQueue();
+        var articles = new[]
+        {
+            new ArticleToAnalyze("AAPL", "Article 1", null, DateTime.UtcNow),
+            new ArticleToAnalyze("MSFT", "Article 2", null, DateTime.UtcNow),
+            new ArticleToAnalyze("GOOGL", "Article 3", null, DateTime.UtcNow),
+        };
+
+        foreach (var article in articles)
+            await queue.PublishAsync(article);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var received = new List<ArticleToAnalyze>();
+
+        await foreach (var item in queue.ConsumeAsync(cts.Token))
+        {
+            received.Add(item);
+            if (received.Count == 3) break;
+        }
+
+        received.Should().HaveCount(3);
+        received.Select(a => a.Symbol).Should().ContainInOrder("AAPL", "MSFT", "GOOGL");
+    }
+
+    [Fact]
+    public async Task Consume_Cancellation_StopsConsuming()
+    {
+        var queue = new InMemoryArticleQueue();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var received = new List<ArticleToAnalyze>();
+        var act = async () =>
+        {
+            await foreach (var item in queue.ConsumeAsync(cts.Token))
+                received.Add(item);
+        };
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        received.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- Added 10 new test files covering previously untested areas across all layers
- Test count increased from 97 to 140 (44% more tests)
- Covers: GetSentimentHistoryHandler, GetSentimentStatsHandler, LoggingBehavior, TrackedSymbol entity, SentimentAnalysis edge cases, InMemoryArticleQueue, PagedResult, ValidationException, NotFoundException, DomainException

## New test files
- `Tests/Application/GetSentimentHistoryHandlerTests.cs` — 6 tests for history query handler
- `Tests/Application/GetSentimentStatsHandlerTests.cs` — 7 tests for stats query handler  
- `Tests/Application/LoggingBehaviorTests.cs` — 4 tests for MediatR pipeline logging
- `Tests/Application/PagedResultTests.cs` — 5 tests for pagination math
- `Tests/Application/ValidationExceptionTests.cs` — 3 tests for error grouping
- `Tests/Application/NotFoundExceptionTests.cs` — 2 tests for message formatting
- `Tests/Domain/TrackedSymbolTests.cs` — 7 tests for entity creation/validation
- `Tests/Domain/SentimentAnalysisEdgeCaseTests.cs` — 12 tests for boundary conditions
- `Tests/Domain/DomainExceptionTests.cs` — 3 tests for exception constructors
- `Tests/Infrastructure/InMemoryArticleQueueTests.cs` — 3 tests for channel-based queue

## Test plan
- [x] `dotnet build API/API.csproj` — zero errors
- [x] `dotnet test Tests/Tests.csproj` — all 140 tests pass

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)