### PR TITLE
chore: increase unit test coverage (#39)

### DIFF
--- a/Tests/Application/GetSentimentHistoryHandlerTests.cs
+++ b/Tests/Application/GetSentimentHistoryHandlerTests.cs
@@ -1,0 +1,137 @@
+using Application.Common.Models;
+using Application.Features.Sentiment.Queries.GetSentimentHistory;
+using Domain.Entities;
+using Domain.Interfaces;
+using Domain.ValueObjects;
+using FluentAssertions;
+using NSubstitute;
+
+namespace Tests.Application;
+
+public class GetSentimentHistoryHandlerTests
+{
+    private readonly ISentimentRepository _repository = Substitute.For<ISentimentRepository>();
+
+    private GetSentimentHistoryQueryHandler CreateHandler() => new(_repository);
+
+    private static SentimentAnalysis CreateAnalysis(double score = 0.5, string symbol = "AAPL") =>
+        SentimentAnalysis.Create(
+            new StockSymbol(symbol),
+            "Test article text for analysis.",
+            "https://example.com/article",
+            score,
+            0.85,
+            ["Reason 1", "Reason 2"],
+            "test-model-v1");
+
+    [Fact]
+    public async Task Handle_ValidSymbol_ReturnsMappedDtos()
+    {
+        var analyses = new List<SentimentAnalysis> { CreateAnalysis(0.6), CreateAnalysis(0.3) };
+        _repository.GetHistoryAsync(
+                Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<int>(),
+                Arg.Any<DateTime?>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns((analyses, 2));
+
+        var query = new GetSentimentHistoryQuery("AAPL");
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        result.Items.Should().HaveCount(2);
+        result.TotalCount.Should().Be(2);
+        result.Page.Should().Be(1);
+        result.PageSize.Should().Be(20);
+    }
+
+    [Fact]
+    public async Task Handle_MapsScoreCorrectly()
+    {
+        var analysis = CreateAnalysis(0.75);
+        _repository.GetHistoryAsync(
+                Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<int>(),
+                Arg.Any<DateTime?>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns((new List<SentimentAnalysis> { analysis }, 1));
+
+        var query = new GetSentimentHistoryQuery("AAPL");
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        var dto = result.Items.Single();
+        dto.Score.Should().Be(0.75);
+        dto.Label.Should().Be("Positive");
+        dto.Confidence.Should().Be(0.85);
+        dto.KeyReasons.Should().BeEquivalentTo(["Reason 1", "Reason 2"]);
+        dto.ModelVersion.Should().Be("test-model-v1");
+        dto.SourceUrl.Should().Be("https://example.com/article");
+    }
+
+    [Fact]
+    public async Task Handle_EmptyHistory_ReturnsEmptyPagedResult()
+    {
+        _repository.GetHistoryAsync(
+                Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<int>(),
+                Arg.Any<DateTime?>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns((new List<SentimentAnalysis>(), 0));
+
+        var query = new GetSentimentHistoryQuery("AAPL");
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        result.Items.Should().BeEmpty();
+        result.TotalCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_PassesSymbolToRepository()
+    {
+        _repository.GetHistoryAsync(
+                Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<int>(),
+                Arg.Any<DateTime?>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns((new List<SentimentAnalysis>(), 0));
+
+        var query = new GetSentimentHistoryQuery("msft");
+        await CreateHandler().Handle(query, CancellationToken.None);
+
+        await _repository.Received(1).GetHistoryAsync(
+            Arg.Is<StockSymbol>(s => s.Value == "MSFT"),
+            Arg.Is(1), Arg.Is(20),
+            Arg.Is<DateTime?>(d => d == null), Arg.Is<DateTime?>(d => d == null),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WithDateFilters_PassesDatesToRepository()
+    {
+        var from = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var to = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        _repository.GetHistoryAsync(
+                Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<int>(),
+                Arg.Any<DateTime?>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns((new List<SentimentAnalysis>(), 0));
+
+        var query = new GetSentimentHistoryQuery("AAPL", 2, 10, from, to);
+        await CreateHandler().Handle(query, CancellationToken.None);
+
+        await _repository.Received(1).GetHistoryAsync(
+            Arg.Any<StockSymbol>(),
+            Arg.Is(2), Arg.Is(10),
+            Arg.Is(from), Arg.Is(to),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_CustomPageSize_PassesToRepository()
+    {
+        _repository.GetHistoryAsync(
+                Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<int>(),
+                Arg.Any<DateTime?>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns((new List<SentimentAnalysis>(), 0));
+
+        var query = new GetSentimentHistoryQuery("AAPL", Page: 3, PageSize: 5);
+        await CreateHandler().Handle(query, CancellationToken.None);
+
+        await _repository.Received(1).GetHistoryAsync(
+            Arg.Any<StockSymbol>(),
+            Arg.Is(3), Arg.Is(5),
+            Arg.Any<DateTime?>(), Arg.Any<DateTime?>(),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/Tests/Application/GetSentimentStatsHandlerTests.cs
+++ b/Tests/Application/GetSentimentStatsHandlerTests.cs
@@ -1,0 +1,170 @@
+using Application.Exceptions;
+using Application.Features.Sentiment.Queries.GetSentimentStats;
+using Domain.Entities;
+using Domain.Interfaces;
+using Domain.ValueObjects;
+using FluentAssertions;
+using NSubstitute;
+
+namespace Tests.Application;
+
+public class GetSentimentStatsHandlerTests
+{
+    private readonly ISentimentRepository _repository = Substitute.For<ISentimentRepository>();
+
+    private GetSentimentStatsQueryHandler CreateHandler() => new(_repository);
+
+    private static SentimentAnalysis CreateAnalysis(double score, string symbol = "AAPL") =>
+        SentimentAnalysis.Create(
+            new StockSymbol(symbol),
+            "Test article text for analysis.",
+            "https://example.com/article",
+            score,
+            0.85,
+            ["Reason"],
+            "test-model-v1");
+
+    [Fact]
+    public async Task Handle_NoAnalyses_ThrowsNotFoundException()
+    {
+        _repository.GetForStatsAsync(Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new List<SentimentAnalysis>());
+
+        var query = new GetSentimentStatsQuery("AAPL", 30);
+        var act = async () => await CreateHandler().Handle(query, CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_SingleAnalysis_ReturnsCorrectStats()
+    {
+        var analyses = new List<SentimentAnalysis> { CreateAnalysis(0.6) };
+        _repository.GetForStatsAsync(Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(analyses);
+
+        var query = new GetSentimentStatsQuery("AAPL", 30);
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        result.Symbol.Should().Be("AAPL");
+        result.TotalAnalyses.Should().Be(1);
+        result.AverageScore.Should().Be(0.6);
+        result.AverageConfidence.Should().Be(0.85);
+        result.LatestScore.Should().Be(0.6);
+    }
+
+    [Fact]
+    public async Task Handle_MultipleAnalyses_CalculatesAverageScore()
+    {
+        var analyses = new List<SentimentAnalysis>
+        {
+            CreateAnalysis(0.8),
+            CreateAnalysis(0.4),
+            CreateAnalysis(0.6)
+        };
+        _repository.GetForStatsAsync(Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(analyses);
+
+        var query = new GetSentimentStatsQuery("AAPL", 30);
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        result.AverageScore.Should().Be(0.6);
+        result.TotalAnalyses.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task Handle_AllPositive_ReturnsFullPositiveDistribution()
+    {
+        var analyses = new List<SentimentAnalysis>
+        {
+            CreateAnalysis(0.5),
+            CreateAnalysis(0.8)
+        };
+        _repository.GetForStatsAsync(Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(analyses);
+
+        var query = new GetSentimentStatsQuery("AAPL", 30);
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        result.Distribution.PositivePercent.Should().Be(100.0);
+        result.Distribution.NeutralPercent.Should().Be(0.0);
+        result.Distribution.NegativePercent.Should().Be(0.0);
+    }
+
+    [Fact]
+    public async Task Handle_MixedSentiment_CalculatesDistributionCorrectly()
+    {
+        var analyses = new List<SentimentAnalysis>
+        {
+            CreateAnalysis(0.5),   // Positive
+            CreateAnalysis(0.0),   // Neutral
+            CreateAnalysis(-0.5),  // Negative
+        };
+        _repository.GetForStatsAsync(Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(analyses);
+
+        var query = new GetSentimentStatsQuery("AAPL", 30);
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        result.Distribution.PositivePercent.Should().BeApproximately(33.3, 0.1);
+        result.Distribution.NeutralPercent.Should().BeApproximately(33.3, 0.1);
+        result.Distribution.NegativePercent.Should().BeApproximately(33.3, 0.1);
+    }
+
+    [Fact]
+    public async Task Handle_IdentifiesHighestAndLowestScores()
+    {
+        var analyses = new List<SentimentAnalysis>
+        {
+            CreateAnalysis(0.2),
+            CreateAnalysis(0.9),
+            CreateAnalysis(-0.3)
+        };
+        _repository.GetForStatsAsync(Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(analyses);
+
+        var query = new GetSentimentStatsQuery("AAPL", 30);
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        result.HighestScore.Score.Should().Be(0.9);
+        result.LowestScore.Score.Should().Be(-0.3);
+    }
+
+    [Fact]
+    public async Task Handle_SingleAnalysis_TrendIsStable()
+    {
+        var analyses = new List<SentimentAnalysis> { CreateAnalysis(0.5) };
+        _repository.GetForStatsAsync(Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(analyses);
+
+        var query = new GetSentimentStatsQuery("AAPL", 30);
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        result.Trend.Direction.Should().Be("Stable");
+        result.Trend.Slope.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_UppercasesSymbolInput()
+    {
+        _repository.GetForStatsAsync(Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new List<SentimentAnalysis> { CreateAnalysis(0.5) });
+
+        var query = new GetSentimentStatsQuery("aapl", 7);
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        result.Symbol.Should().Be("AAPL");
+    }
+
+    [Fact]
+    public async Task Handle_PeriodReflectsRequestedDays()
+    {
+        _repository.GetForStatsAsync(Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new List<SentimentAnalysis> { CreateAnalysis(0.5) });
+
+        var query = new GetSentimentStatsQuery("AAPL", 7);
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        result.Period.Days.Should().Be(7);
+    }
+}

--- a/Tests/Application/LogAnalysisCompletedHandlerTests.cs
+++ b/Tests/Application/LogAnalysisCompletedHandlerTests.cs
@@ -1,0 +1,39 @@
+using Application.Features.Sentiment.Commands.AnalyzeSentiment;
+using Domain.ValueObjects;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Tests.Application;
+
+public class LogAnalysisCompletedHandlerTests
+{
+    private readonly ILogger<LogAnalysisCompletedHandler> _logger =
+        Substitute.For<ILogger<LogAnalysisCompletedHandler>>();
+
+    private LogAnalysisCompletedHandler CreateHandler() => new(_logger);
+
+    [Fact]
+    public async Task Handle_LogsAnalysisCompletion()
+    {
+        var notification = new SentimentAnalysisCreatedNotification(
+            Guid.NewGuid(), new StockSymbol("AAPL"));
+
+        var act = async () => await CreateHandler().Handle(notification, CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task Handle_CompletesSuccessfully()
+    {
+        var notification = new SentimentAnalysisCreatedNotification(
+            Guid.NewGuid(), new StockSymbol("TSLA"));
+
+        var handler = CreateHandler();
+        var result = handler.Handle(notification, CancellationToken.None);
+
+        await result;
+        result.IsCompletedSuccessfully.Should().BeTrue();
+    }
+}

--- a/Tests/Application/LoggingBehaviorTests.cs
+++ b/Tests/Application/LoggingBehaviorTests.cs
@@ -1,0 +1,52 @@
+using Application.Behaviors;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Tests.Application;
+
+public class LoggingBehaviorTests
+{
+    private readonly ILogger<LoggingBehavior<TestRequest, TestResponse>> _logger =
+        Substitute.For<ILogger<LoggingBehavior<TestRequest, TestResponse>>>();
+
+    public record TestRequest : IRequest<TestResponse>;
+    public record TestResponse(string Value);
+
+    private LoggingBehavior<TestRequest, TestResponse> CreateBehavior() => new(_logger);
+
+    [Fact]
+    public async Task Handle_SuccessfulRequest_ReturnsResponse()
+    {
+        var expected = new TestResponse("ok");
+        var next = Substitute.For<RequestHandlerDelegate<TestResponse>>();
+        next().Returns(expected);
+
+        var result = await CreateBehavior().Handle(new TestRequest(), next, CancellationToken.None);
+
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task Handle_SuccessfulRequest_CallsNext()
+    {
+        var next = Substitute.For<RequestHandlerDelegate<TestResponse>>();
+        next().Returns(new TestResponse("ok"));
+
+        await CreateBehavior().Handle(new TestRequest(), next, CancellationToken.None);
+
+        await next.Received(1)();
+    }
+
+    [Fact]
+    public async Task Handle_FailingRequest_RethrowsException()
+    {
+        var next = Substitute.For<RequestHandlerDelegate<TestResponse>>();
+        next().Returns<TestResponse>(_ => throw new InvalidOperationException("boom"));
+
+        var act = async () => await CreateBehavior().Handle(new TestRequest(), next, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("boom");
+    }
+}

--- a/Tests/Domain/PagedResultTests.cs
+++ b/Tests/Domain/PagedResultTests.cs
@@ -1,0 +1,51 @@
+using Application.Common.Models;
+using FluentAssertions;
+
+namespace Tests.Domain;
+
+public class PagedResultTests
+{
+    [Fact]
+    public void TotalPages_ExactDivision_ReturnsCorrectCount()
+    {
+        var result = new PagedResult<string>(["a", "b"], 10, 1, 5);
+
+        result.TotalPages.Should().Be(2);
+    }
+
+    [Fact]
+    public void TotalPages_PartialLastPage_RoundsUp()
+    {
+        var result = new PagedResult<string>(["a"], 11, 1, 5);
+
+        result.TotalPages.Should().Be(3);
+    }
+
+    [Fact]
+    public void TotalPages_SingleItem_ReturnsOne()
+    {
+        var result = new PagedResult<string>(["a"], 1, 1, 10);
+
+        result.TotalPages.Should().Be(1);
+    }
+
+    [Fact]
+    public void TotalPages_ZeroItems_ReturnsZero()
+    {
+        var result = new PagedResult<string>([], 0, 1, 10);
+
+        result.TotalPages.Should().Be(0);
+    }
+
+    [Fact]
+    public void Properties_ReturnConstructorValues()
+    {
+        var items = new List<string> { "a", "b" };
+        var result = new PagedResult<string>(items, 50, 3, 10);
+
+        result.Items.Should().BeEquivalentTo(items);
+        result.TotalCount.Should().Be(50);
+        result.Page.Should().Be(3);
+        result.PageSize.Should().Be(10);
+    }
+}

--- a/Tests/Domain/TrackedSymbolTests.cs
+++ b/Tests/Domain/TrackedSymbolTests.cs
@@ -1,0 +1,83 @@
+using Domain.Entities;
+using Domain.Exceptions;
+using FluentAssertions;
+
+namespace Tests.Domain;
+
+public class TrackedSymbolTests
+{
+    [Fact]
+    public void Create_ValidSymbol_ReturnsEntityWithCorrectValues()
+    {
+        var symbol = TrackedSymbol.Create("AAPL");
+
+        symbol.Symbol.Should().Be("AAPL");
+        symbol.Id.Should().NotBeEmpty();
+        symbol.AddedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public void Create_LowercaseSymbol_ConvertsToUppercase()
+    {
+        var symbol = TrackedSymbol.Create("msft");
+
+        symbol.Symbol.Should().Be("MSFT");
+    }
+
+    [Fact]
+    public void Create_MixedCaseSymbol_ConvertsToUppercase()
+    {
+        var symbol = TrackedSymbol.Create("GoOg");
+
+        symbol.Symbol.Should().Be("GOOG");
+    }
+
+    [Fact]
+    public void Create_EmptySymbol_ThrowsDomainException()
+    {
+        var act = () => TrackedSymbol.Create("");
+
+        act.Should().Throw<DomainException>().WithMessage("*cannot be empty*");
+    }
+
+    [Fact]
+    public void Create_WhitespaceSymbol_ThrowsDomainException()
+    {
+        var act = () => TrackedSymbol.Create("   ");
+
+        act.Should().Throw<DomainException>().WithMessage("*cannot be empty*");
+    }
+
+    [Fact]
+    public void Create_NullSymbol_ThrowsDomainException()
+    {
+        var act = () => TrackedSymbol.Create(null!);
+
+        act.Should().Throw<DomainException>().WithMessage("*cannot be empty*");
+    }
+
+    [Fact]
+    public void Create_SymbolExceeds10Characters_ThrowsDomainException()
+    {
+        var act = () => TrackedSymbol.Create("ABCDEFGHIJK");
+
+        act.Should().Throw<DomainException>().WithMessage("*cannot exceed 10 characters*");
+    }
+
+    [Fact]
+    public void Create_SymbolExactly10Characters_Succeeds()
+    {
+        var act = () => TrackedSymbol.Create("ABCDEFGHIJ");
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Create_GeneratesUniqueIds()
+    {
+        var a = TrackedSymbol.Create("AAPL");
+        var b = TrackedSymbol.Create("AAPL");
+
+        a.Id.Should().NotBe(b.Id);
+    }
+}


### PR DESCRIPTION
## Summary
- Add 34 new unit tests across 6 new test files covering previously untested code
- **GetSentimentHistoryHandlerTests**: pagination, date filters, DTO mapping, symbol pass-through
- **GetSentimentStatsHandlerTests**: NotFoundException on empty data, average calculations, distribution percentages, trend stability, period days
- **TrackedSymbolTests**: Create factory method validation (empty, null, whitespace, length), uppercase conversion, unique ID generation
- **LogAnalysisCompletedHandlerTests**: notification handler completion
- **LoggingBehaviorTests**: pipeline behavior delegates to next, rethrows exceptions
- **PagedResultTests**: TotalPages calculation (exact division, partial page, zero items)

Closes #39

## Test plan
- [x] `dotnet build API/API.csproj` passes with zero errors
- [x] `dotnet test Tests/Tests.csproj` — all 116 tests pass (was 82 before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)