### PR TITLE
Bulk symbol seeding by predefined group

### DIFF
--- a/API/Controllers/SymbolsController.cs
+++ b/API/Controllers/SymbolsController.cs
@@ -2,6 +2,8 @@ using API.Controllers.DTOs;
 using Application.Features.Symbols;
 using Application.Features.Symbols.Commands.AddTrackedSymbol;
 using Application.Features.Symbols.Commands.RemoveTrackedSymbol;
+using Application.Features.Symbols.Commands.SeedSymbols;
+using Application.Features.Symbols.Queries.GetSymbolGroups;
 using Application.Features.Symbols.Queries.GetTrackedSymbols;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
@@ -54,5 +56,29 @@ public class SymbolsController(ISender sender) : ControllerBase
     {
         await sender.Send(new RemoveTrackedSymbolCommand(symbol), ct);
         return NoContent();
+    }
+
+    /// <summary>
+    /// Bulk-seed symbols from a predefined group (e.g. us-bluechip, crypto, tech, etfs, asx-bluechip).
+    /// Duplicates are silently skipped — safe to call multiple times.
+    /// </summary>
+    [HttpPost("seed")]
+    [ProducesResponseType(typeof(SeedSymbolsResultDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Seed([FromQuery] string group, CancellationToken ct)
+    {
+        var result = await sender.Send(new SeedSymbolsCommand(group), ct);
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// List all available symbol groups that can be used with the seed endpoint.
+    /// </summary>
+    [HttpGet("groups")]
+    [ProducesResponseType(typeof(IReadOnlyList<SymbolGroupDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetGroups(CancellationToken ct)
+    {
+        var result = await sender.Send(new GetSymbolGroupsQuery(), ct);
+        return Ok(result);
     }
 }

--- a/Application/Features/Symbols/Commands/SeedSymbols/SeedSymbolsCommand.cs
+++ b/Application/Features/Symbols/Commands/SeedSymbols/SeedSymbolsCommand.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace Application.Features.Symbols.Commands.SeedSymbols;
+
+public record SeedSymbolsCommand(string Group) : IRequest<SeedSymbolsResultDto>;

--- a/Application/Features/Symbols/Commands/SeedSymbols/SeedSymbolsCommandHandler.cs
+++ b/Application/Features/Symbols/Commands/SeedSymbols/SeedSymbolsCommandHandler.cs
@@ -1,0 +1,42 @@
+using Domain;
+using Domain.Entities;
+using Domain.Enums;
+using Domain.Interfaces;
+using MediatR;
+
+namespace Application.Features.Symbols.Commands.SeedSymbols;
+
+public class SeedSymbolsCommandHandler(ITrackedSymbolRepository repository)
+    : IRequestHandler<SeedSymbolsCommand, SeedSymbolsResultDto>
+{
+    public async Task<SeedSymbolsResultDto> Handle(
+        SeedSymbolsCommand request, CancellationToken cancellationToken)
+    {
+        var groupEnum = Enum.Parse<SymbolGroup>(
+            SeedSymbolsCommandValidator.NormaliseGroupName(request.Group), ignoreCase: true);
+
+        var symbols = SymbolGroupDefinitions.GetSymbols(groupEnum)!;
+
+        var added = new List<string>();
+        var skipped = 0;
+
+        foreach (var symbol in symbols)
+        {
+            if (await repository.ExistsAsync(symbol, cancellationToken))
+            {
+                skipped++;
+                continue;
+            }
+
+            var entity = TrackedSymbol.Create(symbol);
+            await repository.AddAsync(entity, cancellationToken);
+            added.Add(symbol);
+        }
+
+        return new SeedSymbolsResultDto(
+            Group: request.Group,
+            Added: added.Count,
+            Skipped: skipped,
+            AddedSymbols: added);
+    }
+}

--- a/Application/Features/Symbols/Commands/SeedSymbols/SeedSymbolsCommandValidator.cs
+++ b/Application/Features/Symbols/Commands/SeedSymbols/SeedSymbolsCommandValidator.cs
@@ -1,0 +1,38 @@
+using Domain.Enums;
+using FluentValidation;
+
+namespace Application.Features.Symbols.Commands.SeedSymbols;
+
+public class SeedSymbolsCommandValidator : AbstractValidator<SeedSymbolsCommand>
+{
+    public SeedSymbolsCommandValidator()
+    {
+        RuleFor(x => x.Group)
+            .NotEmpty().WithMessage("Group name is required.")
+            .Must(BeAValidGroup).WithMessage(
+                $"Unknown group. Available groups: {string.Join(", ", Enum.GetNames<SymbolGroup>().Select(FormatGroupName))}");
+    }
+
+    private static bool BeAValidGroup(string group) =>
+        Enum.TryParse<SymbolGroup>(NormaliseGroupName(group), ignoreCase: true, out _);
+
+    /// <summary>
+    /// Converts kebab-case group names (e.g. "us-bluechip") to PascalCase enum names (e.g. "UsBluechip").
+    /// </summary>
+    public static string NormaliseGroupName(string input) =>
+        string.Concat(input.Split('-').Select(part =>
+            part.Length == 0 ? "" : char.ToUpperInvariant(part[0]) + part[1..].ToLowerInvariant()));
+
+    private static string FormatGroupName(string enumName)
+    {
+        // Convert PascalCase to kebab-case for display
+        var chars = new List<char>();
+        for (int i = 0; i < enumName.Length; i++)
+        {
+            if (i > 0 && char.IsUpper(enumName[i]))
+                chars.Add('-');
+            chars.Add(char.ToLowerInvariant(enumName[i]));
+        }
+        return new string(chars.ToArray());
+    }
+}

--- a/Application/Features/Symbols/Queries/GetSymbolGroups/GetSymbolGroupsQuery.cs
+++ b/Application/Features/Symbols/Queries/GetSymbolGroups/GetSymbolGroupsQuery.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace Application.Features.Symbols.Queries.GetSymbolGroups;
+
+public record GetSymbolGroupsQuery : IRequest<IReadOnlyList<SymbolGroupDto>>;

--- a/Application/Features/Symbols/Queries/GetSymbolGroups/GetSymbolGroupsQueryHandler.cs
+++ b/Application/Features/Symbols/Queries/GetSymbolGroups/GetSymbolGroupsQueryHandler.cs
@@ -1,0 +1,34 @@
+using Domain;
+using Domain.Enums;
+using MediatR;
+
+namespace Application.Features.Symbols.Queries.GetSymbolGroups;
+
+public class GetSymbolGroupsQueryHandler
+    : IRequestHandler<GetSymbolGroupsQuery, IReadOnlyList<SymbolGroupDto>>
+{
+    public Task<IReadOnlyList<SymbolGroupDto>> Handle(
+        GetSymbolGroupsQuery request, CancellationToken cancellationToken)
+    {
+        var groups = SymbolGroupDefinitions.AvailableGroups
+            .Select(g => new SymbolGroupDto(
+                Name: FormatGroupName(g),
+                Symbols: SymbolGroupDefinitions.GetSymbols(g)!))
+            .ToList();
+
+        return Task.FromResult<IReadOnlyList<SymbolGroupDto>>(groups);
+    }
+
+    private static string FormatGroupName(SymbolGroup group)
+    {
+        var name = group.ToString();
+        var chars = new List<char>();
+        for (int i = 0; i < name.Length; i++)
+        {
+            if (i > 0 && char.IsUpper(name[i]))
+                chars.Add('-');
+            chars.Add(char.ToLowerInvariant(name[i]));
+        }
+        return new string(chars.ToArray());
+    }
+}

--- a/Application/Features/Symbols/SeedSymbolsResultDto.cs
+++ b/Application/Features/Symbols/SeedSymbolsResultDto.cs
@@ -1,0 +1,10 @@
+namespace Application.Features.Symbols;
+
+/// <summary>
+/// Result of a bulk seed operation — tells the caller what was added vs skipped.
+/// </summary>
+public record SeedSymbolsResultDto(
+    string Group,
+    int Added,
+    int Skipped,
+    IReadOnlyList<string> AddedSymbols);

--- a/Application/Features/Symbols/SymbolGroupDto.cs
+++ b/Application/Features/Symbols/SymbolGroupDto.cs
@@ -1,0 +1,3 @@
+namespace Application.Features.Symbols;
+
+public record SymbolGroupDto(string Name, IReadOnlyList<string> Symbols);

--- a/Domain/Enums/SymbolGroup.cs
+++ b/Domain/Enums/SymbolGroup.cs
@@ -1,0 +1,13 @@
+namespace Domain.Enums;
+
+/// <summary>
+/// Predefined groups of symbols that can be bulk-seeded into the tracking list.
+/// </summary>
+public enum SymbolGroup
+{
+    UsBluechip,
+    AsxBluechip,
+    Crypto,
+    Tech,
+    Etfs
+}

--- a/Domain/SymbolGroupDefinitions.cs
+++ b/Domain/SymbolGroupDefinitions.cs
@@ -1,0 +1,53 @@
+using Domain.Enums;
+
+namespace Domain;
+
+/// <summary>
+/// Curated lists of symbols for bulk seeding. These are static reference data
+/// owned by the domain — no external dependencies required.
+/// </summary>
+public static class SymbolGroupDefinitions
+{
+    private static readonly IReadOnlyDictionary<SymbolGroup, IReadOnlyList<string>> Groups =
+        new Dictionary<SymbolGroup, IReadOnlyList<string>>
+        {
+            [SymbolGroup.UsBluechip] =
+            [
+                "AAPL", "MSFT", "GOOGL", "AMZN", "NVDA", "META", "TSLA", "JPM", "V", "JNJ",
+                "UNH", "WMT", "PG", "MA", "HD", "BAC", "XOM", "KO", "PFE", "ABBV",
+                "CVX", "MRK", "COST", "PEP", "TMO", "AVGO", "LLY", "ORCL", "CSCO", "ACN"
+            ],
+            [SymbolGroup.AsxBluechip] =
+            [
+                "BHP.AX", "CBA.AX", "CSL.AX", "WBC.AX", "ANZ.AX", "NAB.AX", "WES.AX",
+                "MQG.AX", "FMG.AX", "TLS.AX", "WOW.AX", "RIO.AX", "ALL.AX", "STO.AX",
+                "COL.AX", "QBE.AX", "NCM.AX", "WPL.AX", "TCL.AX", "AMC.AX"
+            ],
+            [SymbolGroup.Crypto] =
+            [
+                "BTC-USD", "ETH-USD", "SOL-USD", "XRP-USD", "ADA-USD", "DOGE-USD",
+                "AVAX-USD", "DOT-USD", "MATIC-USD", "LINK-USD", "ATOM-USD", "UNI-USD",
+                "LTC-USD", "BCH-USD", "NEAR-USD"
+            ],
+            [SymbolGroup.Tech] =
+            [
+                "AAPL", "MSFT", "GOOGL", "META", "NVDA", "AMD", "INTC", "CRM", "ORCL", "ADBE",
+                "CSCO", "AVGO", "TXN", "QCOM", "NOW", "PANW", "SNPS", "CDNS", "MRVL", "KLAC"
+            ],
+            [SymbolGroup.Etfs] =
+            [
+                "SPY", "QQQ", "IWM", "DIA", "VTI", "VOO", "VEA", "VWO", "BND", "GLD"
+            ]
+        };
+
+    /// <summary>
+    /// Returns the symbols in the given group, or null if the group is not defined.
+    /// </summary>
+    public static IReadOnlyList<string>? GetSymbols(SymbolGroup group) =>
+        Groups.GetValueOrDefault(group);
+
+    /// <summary>
+    /// Returns all available group names.
+    /// </summary>
+    public static IReadOnlyList<SymbolGroup> AvailableGroups => Groups.Keys.ToList().AsReadOnly();
+}

--- a/Tests/Application/SeedSymbolsHandlerTests.cs
+++ b/Tests/Application/SeedSymbolsHandlerTests.cs
@@ -1,0 +1,148 @@
+using Application.Features.Symbols.Commands.SeedSymbols;
+using Domain.Entities;
+using Domain.Interfaces;
+using FluentAssertions;
+using NSubstitute;
+
+namespace Tests.Application;
+
+public class SeedSymbolsHandlerTests
+{
+    private readonly ITrackedSymbolRepository _repository = Substitute.For<ITrackedSymbolRepository>();
+
+    private SeedSymbolsCommandHandler CreateHandler() => new(_repository);
+
+    [Fact]
+    public async Task Handle_ValidGroup_AddsAllNewSymbols()
+    {
+        _repository.ExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+
+        var result = await CreateHandler().Handle(
+            new SeedSymbolsCommand("crypto"), CancellationToken.None);
+
+        result.Group.Should().Be("crypto");
+        result.Added.Should().Be(15);
+        result.Skipped.Should().Be(0);
+        result.AddedSymbols.Should().Contain("BTC-USD");
+        result.AddedSymbols.Should().Contain("ETH-USD");
+        await _repository.Received(15).AddAsync(Arg.Any<TrackedSymbol>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WithExistingSymbols_SkipsDuplicates()
+    {
+        _repository.ExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+        _repository.ExistsAsync("BTC-USD", Arg.Any<CancellationToken>()).Returns(true);
+        _repository.ExistsAsync("ETH-USD", Arg.Any<CancellationToken>()).Returns(true);
+
+        var result = await CreateHandler().Handle(
+            new SeedSymbolsCommand("crypto"), CancellationToken.None);
+
+        result.Added.Should().Be(13);
+        result.Skipped.Should().Be(2);
+        result.AddedSymbols.Should().NotContain("BTC-USD");
+        result.AddedSymbols.Should().NotContain("ETH-USD");
+    }
+
+    [Fact]
+    public async Task Handle_AllSymbolsExist_ReturnsZeroAdded()
+    {
+        _repository.ExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
+
+        var result = await CreateHandler().Handle(
+            new SeedSymbolsCommand("etfs"), CancellationToken.None);
+
+        result.Added.Should().Be(0);
+        result.Skipped.Should().Be(10);
+        result.AddedSymbols.Should().BeEmpty();
+        await _repository.DidNotReceive().AddAsync(Arg.Any<TrackedSymbol>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_KebabCaseGroupName_ParsesCorrectly()
+    {
+        _repository.ExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+
+        var result = await CreateHandler().Handle(
+            new SeedSymbolsCommand("us-bluechip"), CancellationToken.None);
+
+        result.Group.Should().Be("us-bluechip");
+        result.Added.Should().Be(30);
+        result.AddedSymbols.Should().Contain("AAPL");
+        result.AddedSymbols.Should().Contain("MSFT");
+    }
+
+    [Fact]
+    public async Task Handle_UsBluechipGroup_ContainsExpectedSymbols()
+    {
+        _repository.ExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+
+        var result = await CreateHandler().Handle(
+            new SeedSymbolsCommand("us-bluechip"), CancellationToken.None);
+
+        result.AddedSymbols.Should().Contain("AAPL");
+        result.AddedSymbols.Should().Contain("JPM");
+        result.AddedSymbols.Should().Contain("NVDA");
+    }
+
+    [Fact]
+    public async Task Handle_TechGroup_ContainsExpectedSymbols()
+    {
+        _repository.ExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+
+        var result = await CreateHandler().Handle(
+            new SeedSymbolsCommand("tech"), CancellationToken.None);
+
+        result.AddedSymbols.Should().Contain("AMD");
+        result.AddedSymbols.Should().Contain("ADBE");
+        result.AddedSymbols.Should().Contain("CRM");
+    }
+
+    [Fact]
+    public async Task Handle_AsxBluechipGroup_ContainsExpectedSymbols()
+    {
+        _repository.ExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+
+        var result = await CreateHandler().Handle(
+            new SeedSymbolsCommand("asx-bluechip"), CancellationToken.None);
+
+        result.AddedSymbols.Should().Contain("BHP.AX");
+        result.AddedSymbols.Should().Contain("CBA.AX");
+        result.Added.Should().Be(20);
+    }
+}
+
+public class SeedSymbolsCommandValidatorTests
+{
+    private readonly SeedSymbolsCommandValidator _validator = new();
+
+    [Theory]
+    [InlineData("us-bluechip")]
+    [InlineData("asx-bluechip")]
+    [InlineData("crypto")]
+    [InlineData("tech")]
+    [InlineData("etfs")]
+    public void Validate_ValidGroupName_Succeeds(string group)
+    {
+        var result = _validator.Validate(new SeedSymbolsCommand(group));
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("nonexistent")]
+    [InlineData("invalid-group-name")]
+    public void Validate_InvalidGroupName_Fails(string group)
+    {
+        var result = _validator.Validate(new SeedSymbolsCommand(group));
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void NormaliseGroupName_KebabCase_ReturnsPascalCase()
+    {
+        SeedSymbolsCommandValidator.NormaliseGroupName("us-bluechip").Should().Be("UsBluechip");
+        SeedSymbolsCommandValidator.NormaliseGroupName("asx-bluechip").Should().Be("AsxBluechip");
+        SeedSymbolsCommandValidator.NormaliseGroupName("crypto").Should().Be("Crypto");
+    }
+}

--- a/Tests/Domain/SymbolGroupDefinitionsTests.cs
+++ b/Tests/Domain/SymbolGroupDefinitionsTests.cs
@@ -1,0 +1,78 @@
+using Domain;
+using Domain.Enums;
+using FluentAssertions;
+
+namespace Tests.Domain;
+
+public class SymbolGroupDefinitionsTests
+{
+    [Theory]
+    [InlineData(SymbolGroup.UsBluechip, 30)]
+    [InlineData(SymbolGroup.AsxBluechip, 20)]
+    [InlineData(SymbolGroup.Crypto, 15)]
+    [InlineData(SymbolGroup.Tech, 20)]
+    [InlineData(SymbolGroup.Etfs, 10)]
+    public void GetSymbols_ValidGroup_ReturnsExpectedCount(SymbolGroup group, int expectedCount)
+    {
+        var symbols = SymbolGroupDefinitions.GetSymbols(group);
+
+        symbols.Should().NotBeNull();
+        symbols.Should().HaveCount(expectedCount);
+    }
+
+    [Fact]
+    public void GetSymbols_AllSymbolsAreUpperCase()
+    {
+        foreach (var group in SymbolGroupDefinitions.AvailableGroups)
+        {
+            var symbols = SymbolGroupDefinitions.GetSymbols(group)!;
+            symbols.Should().OnlyContain(s => s == s.ToUpperInvariant(),
+                $"all symbols in {group} should be uppercase");
+        }
+    }
+
+    [Fact]
+    public void GetSymbols_AllSymbolsAreWithinLengthLimit()
+    {
+        foreach (var group in SymbolGroupDefinitions.AvailableGroups)
+        {
+            var symbols = SymbolGroupDefinitions.GetSymbols(group)!;
+            symbols.Should().OnlyContain(s => s.Length <= 10,
+                $"all symbols in {group} should be 10 chars or fewer");
+        }
+    }
+
+    [Fact]
+    public void AvailableGroups_ContainsAllExpectedGroups()
+    {
+        SymbolGroupDefinitions.AvailableGroups.Should().Contain(SymbolGroup.UsBluechip);
+        SymbolGroupDefinitions.AvailableGroups.Should().Contain(SymbolGroup.AsxBluechip);
+        SymbolGroupDefinitions.AvailableGroups.Should().Contain(SymbolGroup.Crypto);
+        SymbolGroupDefinitions.AvailableGroups.Should().Contain(SymbolGroup.Tech);
+        SymbolGroupDefinitions.AvailableGroups.Should().Contain(SymbolGroup.Etfs);
+    }
+
+    [Fact]
+    public void AvailableGroups_HasFiveGroups()
+    {
+        SymbolGroupDefinitions.AvailableGroups.Should().HaveCount(5);
+    }
+
+    [Fact]
+    public void GetSymbols_CryptoGroup_ContainsBtcAndEth()
+    {
+        var symbols = SymbolGroupDefinitions.GetSymbols(SymbolGroup.Crypto)!;
+        symbols.Should().Contain("BTC-USD");
+        symbols.Should().Contain("ETH-USD");
+    }
+
+    [Fact]
+    public void GetSymbols_NoDuplicatesWithinGroup()
+    {
+        foreach (var group in SymbolGroupDefinitions.AvailableGroups)
+        {
+            var symbols = SymbolGroupDefinitions.GetSymbols(group)!;
+            symbols.Should().OnlyHaveUniqueItems($"{group} should not have duplicate symbols");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `POST /api/symbols/seed?group=<name>` endpoint to bulk-load curated symbol lists (us-bluechip, asx-bluechip, crypto, tech, etfs)
- Adds `GET /api/symbols/groups` endpoint to discover available groups and their constituent symbols
- Duplicates are silently skipped, making the seed endpoint idempotent and safe to call repeatedly
- Implements Layer 1 of the symbol discovery strategy from issue #33

## Details
**Domain layer** (zero dependencies):
- `SymbolGroup` enum with 5 groups
- `SymbolGroupDefinitions` static class with curated symbol lists (95 total symbols)

**Application layer** (MediatR commands/queries):
- `SeedSymbolsCommand` + handler + FluentValidation validator
- `GetSymbolGroupsQuery` + handler
- Kebab-case group names in API (e.g. `us-bluechip`) mapped to PascalCase enum

**API layer** (thin controller):
- Two new endpoints on `SymbolsController`

## Test plan
- [x] 7 handler tests: valid groups, duplicate skipping, all-exist case, kebab-case parsing, group-specific symbol verification
- [x] 3 validator tests: valid group names pass, invalid/empty names fail
- [x] 3 normalisation tests: kebab-case to PascalCase conversion
- [x] 8 domain tests: group counts, uppercase enforcement, length limits, no duplicates within groups
- [x] All 109 tests pass (`dotnet test`)

Closes #33

Generated with [Claude Code](https://claude.com/claude-code)