### PR TITLE
fix: pre-filter irrelevant articles before AI analysis

### DIFF
--- a/Application/Services/IArticleRelevanceFilter.cs
+++ b/Application/Services/IArticleRelevanceFilter.cs
@@ -1,0 +1,16 @@
+namespace Application.Services;
+
+/// <summary>
+/// Pre-filters articles before they are sent for AI sentiment analysis.
+/// Rejects obviously irrelevant content (campus events, login pages, etc.)
+/// to avoid wasting AI resources on non-financial articles.
+/// </summary>
+public interface IArticleRelevanceFilter
+{
+    /// <summary>
+    /// Determines whether an article is relevant enough to warrant AI analysis.
+    /// </summary>
+    /// <param name="article">The article to evaluate.</param>
+    /// <returns>True if the article should be analyzed; false if it should be skipped.</returns>
+    bool IsRelevant(ArticleToAnalyze article);
+}

--- a/Infrastructure/DependencyInjection.cs
+++ b/Infrastructure/DependencyInjection.cs
@@ -67,6 +67,7 @@ public static class DependencyInjection
             configuration.GetSection(IngestionOptions.SectionName));
 
         services.AddSingleton<IArticleQueue, InMemoryArticleQueue>();
+        services.AddSingleton<IArticleRelevanceFilter, ArticleRelevanceFilter>();
 
         const string userAgent =
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";

--- a/Infrastructure/Infrastructure.csproj
+++ b/Infrastructure/Infrastructure.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Infrastructure/Ingestion/ArticleRelevanceFilter.cs
+++ b/Infrastructure/Ingestion/ArticleRelevanceFilter.cs
@@ -1,0 +1,132 @@
+using Application.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.Ingestion;
+
+/// <summary>
+/// Filters out articles that are obviously irrelevant to financial sentiment analysis.
+///
+/// Three checks (all conservative — when in doubt, keep the article):
+///   1. Minimum content length — skip near-empty articles
+///   2. URL pattern filter — skip non-news URLs (event registrations, login pages)
+///   3. Keyword check — require at least one financial term OR the symbol/company name
+/// </summary>
+public class ArticleRelevanceFilter(ILogger<ArticleRelevanceFilter> logger) : IArticleRelevanceFilter
+{
+    /// <summary>
+    /// Articles shorter than this are too short to carry meaningful sentiment signal.
+    /// </summary>
+    internal const int MinContentLength = 50;
+
+    /// <summary>
+    /// URL path segments that indicate non-news content.
+    /// </summary>
+    private static readonly string[] IrrelevantUrlPatterns =
+    [
+        "/event", "/events/", "/register", "/registration",
+        "/login", "/signin", "/sign-in", "/signup", "/sign-up",
+        "/campus", "/calendar", "/careers", "/jobs",
+        "/subscribe", "/newsletter"
+    ];
+
+    /// <summary>
+    /// Financial terms that signal an article is worth analyzing.
+    /// Kept broad and lowercase for case-insensitive matching.
+    /// </summary>
+    private static readonly string[] FinancialKeywords =
+    [
+        "stock", "share", "shares", "equity", "equities",
+        "earnings", "revenue", "profit", "loss", "dividend",
+        "market", "trading", "trader", "investor", "investment",
+        "bull", "bear", "rally", "selloff", "sell-off",
+        "ipo", "merger", "acquisition", "buyout",
+        "analyst", "forecast", "guidance", "outlook",
+        "sec", "filing", "10-k", "10-q", "8-k",
+        "price target", "upgrade", "downgrade", "overweight", "underweight",
+        "quarterly", "annual", "fiscal", "financial",
+        "ceo", "cfo", "cto", "executive",
+        "nasdaq", "nyse", "s&p", "dow jones", "wall street",
+        "bond", "yield", "interest rate", "fed", "inflation",
+        "valuation", "p/e", "eps", "ebitda", "cash flow",
+        "growth", "decline", "surge", "plunge", "soar", "tumble",
+        "beat", "miss", "exceed", "disappoint",
+        "buy", "sell", "hold", "outperform", "underperform"
+    ];
+
+    public bool IsRelevant(ArticleToAnalyze article)
+    {
+        if (!PassesMinimumLength(article))
+        {
+            logger.LogDebug(
+                "Filtered article for {Symbol}: content too short ({Length} chars). URL: {Url}",
+                article.Symbol, article.Text.Length, article.SourceUrl ?? "unknown");
+            return false;
+        }
+
+        if (!PassesUrlFilter(article))
+        {
+            logger.LogDebug(
+                "Filtered article for {Symbol}: irrelevant URL pattern. URL: {Url}",
+                article.Symbol, article.SourceUrl ?? "unknown");
+            return false;
+        }
+
+        if (!PassesKeywordCheck(article))
+        {
+            logger.LogDebug(
+                "Filtered article for {Symbol}: no financial keywords found. URL: {Url}",
+                article.Symbol, article.SourceUrl ?? "unknown");
+            return false;
+        }
+
+        return true;
+    }
+
+    internal static bool PassesMinimumLength(ArticleToAnalyze article)
+        => article.Text.Length >= MinContentLength;
+
+    internal static bool PassesUrlFilter(ArticleToAnalyze article)
+    {
+        if (string.IsNullOrWhiteSpace(article.SourceUrl))
+            return true; // No URL to check — keep the article
+
+        var lowerUrl = article.SourceUrl.ToLowerInvariant();
+        return !IrrelevantUrlPatterns.Any(pattern => lowerUrl.Contains(pattern));
+    }
+
+    internal static bool PassesKeywordCheck(ArticleToAnalyze article)
+    {
+        var lowerText = article.Text.ToLowerInvariant();
+
+        // Check if the symbol itself appears in the text (whole word to avoid partial matches)
+        if (ContainsWholeWord(lowerText, article.Symbol.ToLowerInvariant()))
+            return true;
+
+        // Check for any financial keyword
+        return FinancialKeywords.Any(keyword => keyword.Length <= 3
+            ? ContainsWholeWord(lowerText, keyword)
+            : lowerText.Contains(keyword));
+    }
+
+    /// <summary>
+    /// Checks if a word appears as a whole word (not as a substring of another word).
+    /// Boundaries are non-alphanumeric characters or start/end of string.
+    /// </summary>
+    private static bool ContainsWholeWord(string text, string word)
+    {
+        var index = 0;
+        while ((index = text.IndexOf(word, index, StringComparison.Ordinal)) >= 0)
+        {
+            var before = index == 0 || !char.IsLetterOrDigit(text[index - 1]);
+            var afterPos = index + word.Length;
+            var after = afterPos >= text.Length || !char.IsLetterOrDigit(text[afterPos]);
+
+            if (before && after)
+                return true;
+
+            index += word.Length;
+        }
+
+        return false;
+    }
+}

--- a/Infrastructure/Ingestion/SentimentIngestionWorker.cs
+++ b/Infrastructure/Ingestion/SentimentIngestionWorker.cs
@@ -21,6 +21,7 @@ namespace Infrastructure.Ingestion;
 public class SentimentIngestionWorker(
     IServiceScopeFactory scopeFactory,
     IArticleQueue articleQueue,
+    IArticleRelevanceFilter relevanceFilter,
     IOptionsMonitor<IngestionOptions> options,
     ILogger<SentimentIngestionWorker> logger)
     : BackgroundService
@@ -61,6 +62,8 @@ public class SentimentIngestionWorker(
                 var articles = await newsSourceService.FetchArticlesAsync(symbol, since, ct);
                 var newCount = 0;
 
+                var filteredCount = 0;
+
                 foreach (var article in articles)
                 {
                     var key = article.SourceUrl ?? article.Text.GetHashCode().ToString();
@@ -70,12 +73,21 @@ public class SentimentIngestionWorker(
 
                     _processedUrls.Add(key);
 
-                    await articleQueue.PublishAsync(
-                        new ArticleToAnalyze(symbol.Value, article.Text, article.SourceUrl, article.PublishedAt),
-                        ct);
+                    var candidate = new ArticleToAnalyze(symbol.Value, article.Text, article.SourceUrl, article.PublishedAt);
+
+                    if (!relevanceFilter.IsRelevant(candidate))
+                    {
+                        filteredCount++;
+                        continue;
+                    }
+
+                    await articleQueue.PublishAsync(candidate, ct);
 
                     newCount++;
                 }
+
+                if (filteredCount > 0)
+                    logger.LogInformation("Filtered {FilteredCount} irrelevant articles for {Symbol}", filteredCount, symbol.Value);
 
                 if (newCount > 0)
                     logger.LogInformation("Queued {Count} new articles for {Symbol}", newCount, symbol.Value);

--- a/Tests/Infrastructure/ArticleRelevanceFilterTests.cs
+++ b/Tests/Infrastructure/ArticleRelevanceFilterTests.cs
@@ -1,0 +1,227 @@
+using Application.Services;
+using FluentAssertions;
+using Infrastructure.Ingestion;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Tests.Infrastructure;
+
+public class ArticleRelevanceFilterTests
+{
+    private readonly ArticleRelevanceFilter _filter;
+
+    public ArticleRelevanceFilterTests()
+    {
+        var logger = Substitute.For<ILogger<ArticleRelevanceFilter>>();
+        _filter = new ArticleRelevanceFilter(logger);
+    }
+
+    private static ArticleToAnalyze MakeArticle(
+        string text,
+        string symbol = "AAPL",
+        string? url = "https://finance.yahoo.com/news/article-1") =>
+        new(symbol, text, url, DateTime.UtcNow);
+
+    // --- Minimum content length ---
+
+    [Fact]
+    public void IsRelevant_ShortContent_ReturnsFalse()
+    {
+        var article = MakeArticle("Short text");
+        _filter.IsRelevant(article).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsRelevant_EmptyContent_ReturnsFalse()
+    {
+        var article = MakeArticle(string.Empty);
+        _filter.IsRelevant(article).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsRelevant_ExactlyMinLength_WithKeyword_ReturnsTrue()
+    {
+        // Build a string that is exactly MinContentLength and contains a financial keyword
+        var text = "AAPL stock " + new string('x', ArticleRelevanceFilter.MinContentLength - 11);
+        text.Length.Should().Be(ArticleRelevanceFilter.MinContentLength);
+
+        var article = MakeArticle(text);
+        _filter.IsRelevant(article).Should().BeTrue();
+    }
+
+    // --- URL pattern filter ---
+
+    [Theory]
+    [InlineData("https://example.com/events/campus-fair")]
+    [InlineData("https://example.com/register?id=123")]
+    [InlineData("https://example.com/registration/event")]
+    [InlineData("https://example.com/login")]
+    [InlineData("https://example.com/signin")]
+    [InlineData("https://example.com/careers/apply")]
+    [InlineData("https://example.com/jobs/listing")]
+    [InlineData("https://example.com/calendar/2026")]
+    [InlineData("https://example.com/campus/news")]
+    [InlineData("https://example.com/subscribe")]
+    [InlineData("https://example.com/newsletter")]
+    public void IsRelevant_IrrelevantUrl_ReturnsFalse(string url)
+    {
+        var article = MakeArticle(
+            "Apple stock surges on strong quarterly earnings report, beating analyst estimates significantly.",
+            url: url);
+        _filter.IsRelevant(article).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsRelevant_NullUrl_DoesNotFilter()
+    {
+        var article = MakeArticle(
+            "Apple stock surges on strong quarterly earnings report, beating analyst estimates significantly.",
+            url: null);
+        _filter.IsRelevant(article).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsRelevant_NormalNewsUrl_DoesNotFilter()
+    {
+        var article = MakeArticle(
+            "Apple stock surges on strong quarterly earnings report, beating analyst estimates significantly.",
+            url: "https://finance.yahoo.com/news/apple-earnings-2026");
+        _filter.IsRelevant(article).Should().BeTrue();
+    }
+
+    // --- Keyword check ---
+
+    [Fact]
+    public void IsRelevant_ContainsSymbol_ReturnsTrue()
+    {
+        var article = MakeArticle(
+            "AAPL continues its upward trend amid positive market conditions and increased consumer demand.",
+            symbol: "AAPL");
+        _filter.IsRelevant(article).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsRelevant_ContainsFinancialKeywords_ReturnsTrue()
+    {
+        var article = MakeArticle(
+            "The company reported strong quarterly earnings, with revenue exceeding analyst expectations by a wide margin.");
+        _filter.IsRelevant(article).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsRelevant_StockPriceArticle_ReturnsTrue()
+    {
+        var article = MakeArticle(
+            "Apple shares surged 5% after the company announced a record dividend and a massive stock buyback program.");
+        _filter.IsRelevant(article).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsRelevant_AnalystUpgrade_ReturnsTrue()
+    {
+        var article = MakeArticle(
+            "Goldman Sachs analyst upgrades Apple with a new price target of $250, citing strong iPhone demand outlook.");
+        _filter.IsRelevant(article).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsRelevant_CampusEvent_ReturnsFalse()
+    {
+        var article = MakeArticle(
+            "Join us for the annual spring campus carnival this Saturday. Food, games, and live music for all students and families.",
+            url: "https://example.com/news/campus-carnival");
+        _filter.IsRelevant(article).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsRelevant_SportsArticle_ReturnsFalse()
+    {
+        var article = MakeArticle(
+            "The university football team defeated their rivals in a thrilling overtime game, securing their spot in the playoffs.");
+        _filter.IsRelevant(article).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsRelevant_RecipeArticle_ReturnsFalse()
+    {
+        var article = MakeArticle(
+            "Try this delicious homemade pasta recipe with fresh tomatoes, basil, and mozzarella cheese for a perfect Italian dinner.");
+        _filter.IsRelevant(article).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsRelevant_MergerAcquisition_ReturnsTrue()
+    {
+        var article = MakeArticle(
+            "The proposed merger between the two tech giants faces regulatory scrutiny from the FTC and European regulators.");
+        _filter.IsRelevant(article).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsRelevant_FedInterestRate_ReturnsTrue()
+    {
+        var article = MakeArticle(
+            "The Fed is expected to hold interest rates steady at its next meeting, according to market expectations and recent data.");
+        _filter.IsRelevant(article).Should().BeTrue();
+    }
+
+    // --- Case insensitivity ---
+
+    [Fact]
+    public void IsRelevant_KeywordsCaseInsensitive_ReturnsTrue()
+    {
+        var article = MakeArticle(
+            "QUARTERLY EARNINGS exceeded expectations with REVENUE growth of 15% year-over-year across all segments.");
+        _filter.IsRelevant(article).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsRelevant_SymbolCaseInsensitive_ReturnsTrue()
+    {
+        var article = MakeArticle(
+            "According to analysts, aapl remains a strong buy despite market volatility and macroeconomic uncertainty today.",
+            symbol: "AAPL");
+        _filter.IsRelevant(article).Should().BeTrue();
+    }
+
+    // --- Static helper method tests ---
+
+    [Fact]
+    public void PassesMinimumLength_BelowThreshold_ReturnsFalse()
+    {
+        var article = MakeArticle("Too short");
+        ArticleRelevanceFilter.PassesMinimumLength(article).Should().BeFalse();
+    }
+
+    [Fact]
+    public void PassesUrlFilter_CleanUrl_ReturnsTrue()
+    {
+        var article = MakeArticle("text", url: "https://reuters.com/article/apple-earnings");
+        ArticleRelevanceFilter.PassesUrlFilter(article).Should().BeTrue();
+    }
+
+    [Fact]
+    public void PassesUrlFilter_EventUrl_ReturnsFalse()
+    {
+        var article = MakeArticle("text", url: "https://example.com/events/signup");
+        ArticleRelevanceFilter.PassesUrlFilter(article).Should().BeFalse();
+    }
+
+    [Fact]
+    public void PassesKeywordCheck_NoFinancialContent_ReturnsFalse()
+    {
+        var article = MakeArticle(
+            "Beautiful sunny weather expected this weekend with clear skies and mild temperatures across the region.",
+            symbol: "XYZ");
+        ArticleRelevanceFilter.PassesKeywordCheck(article).Should().BeFalse();
+    }
+
+    [Fact]
+    public void PassesKeywordCheck_WithSymbolInText_ReturnsTrue()
+    {
+        var article = MakeArticle(
+            "According to experts, GOOGL is poised for a breakout this quarter based on recent performance indicators.",
+            symbol: "GOOGL");
+        ArticleRelevanceFilter.PassesKeywordCheck(article).Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- Add `IArticleRelevanceFilter` interface (Application layer) and `ArticleRelevanceFilter` implementation (Infrastructure layer) to reject non-financial articles before they reach the AI provider
- Three conservative filter checks: minimum content length (50 chars), URL pattern exclusion (event/login/campus pages), and financial keyword presence with whole-word matching for short terms (e.g., "sec", "fed", "buy") to avoid false positives
- Integrate filter into `SentimentIngestionWorker` before publishing to `IArticleQueue`, with debug-level logging for rejection tracking and info-level logging for filtered counts per symbol
- Add `InternalsVisibleTo` for Infrastructure project to enable testing internal helper methods

Closes #29

## Test plan
- [x] 22 new unit tests covering all filter logic (min length, URL patterns, keyword matching, case insensitivity, whole-word boundaries)
- [x] Tests for relevant articles: earnings reports, analyst upgrades, merger/acquisition, Fed interest rate, stock price movements
- [x] Tests for irrelevant articles: campus events, sports, recipes, weather
- [x] All 114 tests pass (92 existing + 22 new)
- [ ] Manual: deploy and monitor debug logs to verify rejection rate is reasonable and no financial articles are accidentally filtered

🤖 Generated with [Claude Code](https://claude.com/claude-code)