### PR TITLE
fix: improve crypto symbol news coverage

### DIFF
--- a/Domain/ValueObjects/StockSymbol.cs
+++ b/Domain/ValueObjects/StockSymbol.cs
@@ -15,6 +15,11 @@ public record StockSymbol
         Value = value.ToUpperInvariant();
     }
 
+    /// <summary>
+    /// Returns true for cryptocurrency symbols (e.g. BTC-USD, ETH-USD).
+    /// </summary>
+    public bool IsCrypto => Value.EndsWith("-USD", StringComparison.OrdinalIgnoreCase);
+
     public override string ToString() => Value;
 
     public static implicit operator string(StockSymbol symbol) => symbol.Value;

--- a/Infrastructure/Ingestion/GoogleNewsSourceService.cs
+++ b/Infrastructure/Ingestion/GoogleNewsSourceService.cs
@@ -25,7 +25,8 @@ public class GoogleNewsSourceService(
         DateTime since,
         CancellationToken ct = default)
     {
-        var url = $"https://news.google.com/rss/search?q={Uri.EscapeDataString(symbol.Value + " stock news")}&hl=en-US&gl=US&ceid=US:en";
+        var suffix = symbol.IsCrypto ? "crypto news" : "stock news";
+        var url = $"https://news.google.com/rss/search?q={Uri.EscapeDataString(symbol.Value + " " + suffix)}&hl=en-US&gl=US&ceid=US:en";
 
         try
         {

--- a/Infrastructure/Ingestion/RedditNewsSourceService.cs
+++ b/Infrastructure/Ingestion/RedditNewsSourceService.cs
@@ -6,7 +6,8 @@ using Microsoft.Extensions.Logging;
 namespace Infrastructure.Ingestion;
 
 /// <summary>
-/// Fetches financial news via Reddit RSS search feed for r/stocks.
+/// Fetches financial news via Reddit RSS search feed.
+/// Searches /r/stocks for all symbols, and additionally /r/cryptocurrency for crypto symbols.
 /// No API key required — uses publicly available RSS endpoints.
 ///
 /// RSS XML structure (Atom-flavoured):
@@ -27,28 +28,40 @@ public class RedditNewsSourceService(
         DateTime since,
         CancellationToken ct = default)
     {
-        var url = $"https://www.reddit.com/r/stocks/search.rss?q={Uri.EscapeDataString(symbol.Value)}&restrict_sr=on&sort=new&t=day";
+        var subreddits = symbol.IsCrypto
+            ? new[] { "stocks", "cryptocurrency" }
+            : new[] { "stocks" };
 
-        try
+        var allArticles = new List<FetchedArticle>();
+
+        foreach (var subreddit in subreddits)
         {
-            var xml = await httpClient.GetStringAsync(url, ct);
-            return ParseAtom(xml, since);
+            var url = $"https://www.reddit.com/r/{subreddit}/search.rss?q={Uri.EscapeDataString(symbol.Value)}&restrict_sr=on&sort=new&t=day";
+
+            try
+            {
+                var xml = await httpClient.GetStringAsync(url, ct);
+                allArticles.AddRange(ParseAtom(xml, since));
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (HttpRequestException ex)
+            {
+                logger.LogWarning(ex, "Failed to fetch Reddit RSS feed from r/{Subreddit} for {Symbol}", subreddit, symbol.Value);
+            }
+            catch (XmlException ex)
+            {
+                logger.LogWarning(ex, "Failed to parse Reddit RSS feed from r/{Subreddit} for {Symbol}", subreddit, symbol.Value);
+            }
         }
-        catch (OperationCanceledException)
-        {
-            // Respect cancellation and allow it to propagate.
-            throw;
-        }
-        catch (HttpRequestException ex)
-        {
-            logger.LogWarning(ex, "Failed to fetch Reddit RSS feed for {Symbol}", symbol.Value);
-            return [];
-        }
-        catch (XmlException ex)
-        {
-            logger.LogWarning(ex, "Failed to parse Reddit RSS feed for {Symbol}", symbol.Value);
-            return [];
-        }
+
+        // Deduplicate by URL
+        return allArticles
+            .GroupBy(a => a.SourceUrl)
+            .Select(g => g.First())
+            .ToList();
     }
 
     private static List<FetchedArticle> ParseAtom(string xml, DateTime since)

--- a/Tests/Domain/StockSymbolTests.cs
+++ b/Tests/Domain/StockSymbolTests.cs
@@ -50,4 +50,17 @@ public class StockSymbolTests
         var b = new StockSymbol("aapl"); // uppercased in constructor
         a.Should().Be(b);
     }
+
+    [Theory]
+    [InlineData("BTC-USD", true)]
+    [InlineData("ETH-USD", true)]
+    [InlineData("SOL-USD", true)]
+    [InlineData("AAPL", false)]
+    [InlineData("MSFT", false)]
+    [InlineData("GOOGL", false)]
+    public void IsCrypto_DetectsCryptoSymbolsCorrectly(string input, bool expected)
+    {
+        var symbol = new StockSymbol(input);
+        symbol.IsCrypto.Should().Be(expected);
+    }
 }

--- a/Tests/Infrastructure/GoogleNewsSourceServiceTests.cs
+++ b/Tests/Infrastructure/GoogleNewsSourceServiceTests.cs
@@ -1,0 +1,147 @@
+using System.Net;
+using System.Text;
+using Domain.ValueObjects;
+using FluentAssertions;
+using Infrastructure.Ingestion;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Tests.Infrastructure;
+
+public class GoogleNewsSourceServiceTests
+{
+    private static readonly DateTime Since = DateTime.UtcNow.AddHours(-1);
+
+    private static string BuildRssFeed(params (string title, string url, DateTime pubDate)[] items)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("""<?xml version="1.0" encoding="UTF-8"?>""");
+        sb.AppendLine("<rss version=\"2.0\"><channel>");
+        foreach (var (title, url, pubDate) in items)
+        {
+            sb.AppendLine("<item>");
+            sb.AppendLine($"  <title>{title}</title>");
+            sb.AppendLine($"  <link>{url}</link>");
+            sb.AppendLine($"  <pubDate>{pubDate:R}</pubDate>");
+            sb.AppendLine("</item>");
+        }
+        sb.AppendLine("</channel></rss>");
+        return sb.ToString();
+    }
+
+    private static GoogleNewsSourceService BuildSut(Func<HttpRequestMessage, HttpResponseMessage> handler)
+    {
+        var messageHandler = new FakeHttpMessageHandler(handler);
+        var httpClient = new HttpClient(messageHandler);
+        var logger = Substitute.For<ILogger<GoogleNewsSourceService>>();
+        return new GoogleNewsSourceService(httpClient, logger);
+    }
+
+    // ── Crypto symbol uses "crypto news" suffix ──────────────────────────
+
+    [Fact]
+    public async Task FetchArticlesAsync_CryptoSymbol_UsesCryptoNewsSuffix()
+    {
+        var btc = new StockSymbol("BTC-USD");
+        string? capturedUrl = null;
+
+        var feed = BuildRssFeed(("Bitcoin surges", "https://news.example/1", DateTime.UtcNow));
+
+        var sut = BuildSut(req =>
+        {
+            capturedUrl = req.RequestUri!.ToString();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(feed, Encoding.UTF8, "application/xml")
+            };
+        });
+
+        await sut.FetchArticlesAsync(btc, Since);
+
+        capturedUrl.Should().NotBeNull();
+        capturedUrl.Should().Contain("crypto news");
+        capturedUrl.Should().NotContain("stock news");
+    }
+
+    [Fact]
+    public async Task FetchArticlesAsync_RegularSymbol_UsesStockNewsSuffix()
+    {
+        var aapl = new StockSymbol("AAPL");
+        string? capturedUrl = null;
+
+        var feed = BuildRssFeed(("Apple earnings", "https://news.example/1", DateTime.UtcNow));
+
+        var sut = BuildSut(req =>
+        {
+            capturedUrl = req.RequestUri!.ToString();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(feed, Encoding.UTF8, "application/xml")
+            };
+        });
+
+        await sut.FetchArticlesAsync(aapl, Since);
+
+        capturedUrl.Should().NotBeNull();
+        capturedUrl.Should().Contain("stock news");
+        capturedUrl.Should().NotContain("crypto news");
+    }
+
+    [Theory]
+    [InlineData("ETH-USD")]
+    [InlineData("SOL-USD")]
+    [InlineData("DOGE-USD")]
+    public async Task FetchArticlesAsync_VariousCryptoSymbols_AllUseCryptoNewsSuffix(string symbolValue)
+    {
+        var symbol = new StockSymbol(symbolValue);
+        string? capturedUrl = null;
+
+        var feed = BuildRssFeed(("Crypto headline", "https://news.example/1", DateTime.UtcNow));
+
+        var sut = BuildSut(req =>
+        {
+            capturedUrl = req.RequestUri!.ToString();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(feed, Encoding.UTF8, "application/xml")
+            };
+        });
+
+        await sut.FetchArticlesAsync(symbol, Since);
+
+        capturedUrl.Should().Contain("crypto news");
+    }
+
+    [Theory]
+    [InlineData("AAPL")]
+    [InlineData("MSFT")]
+    [InlineData("GOOGL")]
+    public async Task FetchArticlesAsync_VariousStockSymbols_AllUseStockNewsSuffix(string symbolValue)
+    {
+        var symbol = new StockSymbol(symbolValue);
+        string? capturedUrl = null;
+
+        var feed = BuildRssFeed(("Stock headline", "https://news.example/1", DateTime.UtcNow));
+
+        var sut = BuildSut(req =>
+        {
+            capturedUrl = req.RequestUri!.ToString();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(feed, Encoding.UTF8, "application/xml")
+            };
+        });
+
+        await sut.FetchArticlesAsync(symbol, Since);
+
+        capturedUrl.Should().Contain("stock news");
+    }
+
+    private class FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(handler(request));
+        }
+    }
+}

--- a/Tests/Infrastructure/RedditNewsSourceServiceTests.cs
+++ b/Tests/Infrastructure/RedditNewsSourceServiceTests.cs
@@ -1,0 +1,187 @@
+using System.Net;
+using System.Text;
+using Domain.ValueObjects;
+using FluentAssertions;
+using Infrastructure.Ingestion;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Tests.Infrastructure;
+
+public class RedditNewsSourceServiceTests
+{
+    private static readonly DateTime Since = DateTime.UtcNow.AddHours(-1);
+
+    private static string BuildAtomFeed(params (string title, string url, DateTime updated)[] entries)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("""<?xml version="1.0" encoding="UTF-8"?>""");
+        sb.AppendLine("""<feed xmlns="http://www.w3.org/2005/Atom">""");
+        foreach (var (title, url, updated) in entries)
+        {
+            sb.AppendLine("<entry>");
+            sb.AppendLine($"  <title>{title}</title>");
+            sb.AppendLine($"""  <link href="{url}" />""");
+            sb.AppendLine($"  <updated>{updated:O}</updated>");
+            sb.AppendLine("</entry>");
+        }
+        sb.AppendLine("</feed>");
+        return sb.ToString();
+    }
+
+    private static RedditNewsSourceService BuildSut(Func<HttpRequestMessage, HttpResponseMessage> handler)
+    {
+        var messageHandler = new FakeHttpMessageHandler(handler);
+        var httpClient = new HttpClient(messageHandler);
+        var logger = Substitute.For<ILogger<RedditNewsSourceService>>();
+        return new RedditNewsSourceService(httpClient, logger);
+    }
+
+    // ── Crypto symbol searches both subreddits ───────────────────────────
+
+    [Fact]
+    public async Task FetchArticlesAsync_CryptoSymbol_SearchesBothStocksAndCryptocurrency()
+    {
+        var btc = new StockSymbol("BTC-USD");
+        var requestedUrls = new List<string>();
+
+        var feed = BuildAtomFeed(("Bitcoin rises", "https://reddit.com/r/test/1", DateTime.UtcNow));
+
+        var sut = BuildSut(req =>
+        {
+            requestedUrls.Add(req.RequestUri!.ToString());
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(feed, Encoding.UTF8, "application/xml")
+            };
+        });
+
+        await sut.FetchArticlesAsync(btc, Since);
+
+        requestedUrls.Should().HaveCount(2);
+        requestedUrls.Should().Contain(u => u.Contains("/r/stocks/"));
+        requestedUrls.Should().Contain(u => u.Contains("/r/cryptocurrency/"));
+    }
+
+    [Fact]
+    public async Task FetchArticlesAsync_RegularSymbol_SearchesOnlyStocks()
+    {
+        var aapl = new StockSymbol("AAPL");
+        var requestedUrls = new List<string>();
+
+        var feed = BuildAtomFeed(("Apple earnings", "https://reddit.com/r/test/1", DateTime.UtcNow));
+
+        var sut = BuildSut(req =>
+        {
+            requestedUrls.Add(req.RequestUri!.ToString());
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(feed, Encoding.UTF8, "application/xml")
+            };
+        });
+
+        await sut.FetchArticlesAsync(aapl, Since);
+
+        requestedUrls.Should().ContainSingle();
+        requestedUrls[0].Should().Contain("/r/stocks/");
+    }
+
+    [Fact]
+    public async Task FetchArticlesAsync_CryptoSymbol_DeduplicatesByUrl()
+    {
+        var eth = new StockSymbol("ETH-USD");
+        var sharedUrl = "https://reddit.com/r/shared/1";
+
+        var feed = BuildAtomFeed(("Ethereum news", sharedUrl, DateTime.UtcNow));
+
+        var sut = BuildSut(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(feed, Encoding.UTF8, "application/xml")
+        });
+
+        var result = await sut.FetchArticlesAsync(eth, Since);
+
+        // Both subreddits return the same article URL — should be deduplicated to 1
+        result.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task FetchArticlesAsync_CryptoSymbol_CombinesUniqueArticles()
+    {
+        var btc = new StockSymbol("BTC-USD");
+        var callCount = 0;
+
+        var feed1 = BuildAtomFeed(("Bitcoin from stocks", "https://reddit.com/r/stocks/1", DateTime.UtcNow));
+        var feed2 = BuildAtomFeed(("Bitcoin from crypto", "https://reddit.com/r/crypto/2", DateTime.UtcNow));
+
+        var sut = BuildSut(req =>
+        {
+            var feed = Interlocked.Increment(ref callCount) == 1 ? feed1 : feed2;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(feed, Encoding.UTF8, "application/xml")
+            };
+        });
+
+        var result = await sut.FetchArticlesAsync(btc, Since);
+
+        result.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task FetchArticlesAsync_CryptoSymbol_WhenOneSubredditFails_ReturnsOther()
+    {
+        var btc = new StockSymbol("BTC-USD");
+        var callCount = 0;
+
+        var feed = BuildAtomFeed(("Bitcoin news", "https://reddit.com/r/stocks/1", DateTime.UtcNow));
+
+        var sut = BuildSut(req =>
+        {
+            if (Interlocked.Increment(ref callCount) == 2)
+                throw new HttpRequestException("network error");
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(feed, Encoding.UTF8, "application/xml")
+            };
+        });
+
+        var result = await sut.FetchArticlesAsync(btc, Since);
+
+        result.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task FetchArticlesAsync_AllSubredditsKeepRestrictSrOn()
+    {
+        var btc = new StockSymbol("BTC-USD");
+        var requestedUrls = new List<string>();
+
+        var feed = BuildAtomFeed();
+
+        var sut = BuildSut(req =>
+        {
+            requestedUrls.Add(req.RequestUri!.ToString());
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(feed, Encoding.UTF8, "application/xml")
+            };
+        });
+
+        await sut.FetchArticlesAsync(btc, Since);
+
+        requestedUrls.Should().AllSatisfy(u => u.Should().Contain("restrict_sr=on"));
+    }
+
+    /// <summary>
+    /// Simple fake HTTP message handler for testing.
+    /// </summary>
+    private class FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(handler(request));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `IsCrypto` property to `StockSymbol` value object to detect crypto symbols (those ending in `-USD`)
- `RedditNewsSourceService` now searches both `/r/stocks` and `/r/cryptocurrency` for crypto symbols, deduplicating results by URL
- `GoogleNewsSourceService` now uses `"crypto news"` instead of `"stock news"` as the search suffix for crypto symbols
- Regular stock symbols retain existing behavior (only `/r/stocks`, `"stock news"` suffix)

## Test plan
- [x] `StockSymbol.IsCrypto` correctly identifies BTC-USD, ETH-USD, SOL-USD as crypto and AAPL, MSFT, GOOGL as non-crypto
- [x] `RedditNewsSourceService` searches both subreddits for crypto symbols, only `/r/stocks` for regular symbols
- [x] `RedditNewsSourceService` deduplicates articles with the same URL across subreddits
- [x] `RedditNewsSourceService` returns results from healthy subreddit when the other fails
- [x] `RedditNewsSourceService` keeps `restrict_sr=on` on all requests
- [x] `GoogleNewsSourceService` uses "crypto news" suffix for crypto symbols
- [x] `GoogleNewsSourceService` uses "stock news" suffix for regular symbols
- [x] All 248 tests pass

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)