### PR TITLE
feat: add sortBy/sortDirection query params to trending endpoint

### DIFF
--- a/API/Controllers/SentimentController.cs
+++ b/API/Controllers/SentimentController.cs
@@ -69,9 +69,12 @@ public class SentimentController(ISender sender) : ControllerBase
     public async Task<IActionResult> GetTrending(
         [FromQuery] int hours = 24,
         [FromQuery] int limit = 10,
+        [FromQuery] string? sortBy = null,
+        [FromQuery] string? sortDirection = null,
         CancellationToken ct = default)
     {
-        var result = await sender.Send(new GetTrendingSymbolsQuery(hours, limit), ct);
+        var result = await sender.Send(
+            new GetTrendingSymbolsQuery(hours, limit, sortBy, sortDirection), ct);
         return Ok(result);
     }
 

--- a/API/wwwroot/index.html
+++ b/API/wwwroot/index.html
@@ -49,12 +49,12 @@
                 <table>
                     <thead>
                         <tr>
-                            <th>Symbol</th>
+                            <th data-sort="symbol" onclick="toggleSort('symbol')" style="cursor:pointer">Symbol<span class="sort-indicator"></span></th>
                             <th>Price</th>
                             <th class="sparkline-header">5D</th>
-                            <th>Score</th>
-                            <th>Prev</th>
-                            <th>Delta</th>
+                            <th data-sort="currentAvgScore" onclick="toggleSort('currentAvgScore')" style="cursor:pointer">Score<span class="sort-indicator"></span></th>
+                            <th data-sort="previousAvgScore" onclick="toggleSort('previousAvgScore')" style="cursor:pointer">Prev<span class="sort-indicator"></span></th>
+                            <th data-sort="delta" onclick="toggleSort('delta')" style="cursor:pointer">Delta<span class="sort-indicator"> &#9660;</span></th>
                             <th>Direction</th>
                         </tr>
                     </thead>

--- a/API/wwwroot/js/dashboard.js
+++ b/API/wwwroot/js/dashboard.js
@@ -2,6 +2,8 @@
 
 const API = '';
 let refreshTimer;
+let currentSortBy = 'delta';
+let currentSortDirection = 'desc';
 const priceCache = {};
 
 const SYMBOLS = {
@@ -70,9 +72,33 @@ async function fetchAllPrices(symbols) {
 
 // -- Trending -----------------------------------------------------
 
+function toggleSort(field) {
+    if (currentSortBy === field) {
+        currentSortDirection = currentSortDirection === 'desc' ? 'asc' : 'desc';
+    } else {
+        currentSortBy = field;
+        currentSortDirection = 'desc';
+    }
+    updateSortIndicators();
+    loadTrending();
+}
+
+function updateSortIndicators() {
+    document.querySelectorAll('th[data-sort]').forEach(th => {
+        const indicator = th.querySelector('.sort-indicator');
+        if (!indicator) return;
+        if (th.dataset.sort === currentSortBy) {
+            indicator.textContent = currentSortDirection === 'asc' ? ' \u25B2' : ' \u25BC';
+        } else {
+            indicator.textContent = '';
+        }
+    });
+}
+
 async function loadTrending() {
     try {
-        const res = await fetch(`${API}/api/sentiment/trending?hours=24&limit=20`);
+        const params = new URLSearchParams({ hours: 24, limit: 20, sortBy: currentSortBy, sortDirection: currentSortDirection });
+        const res = await fetch(`${API}/api/sentiment/trending?${params}`);
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data = await res.json();
         setStatus(true);
@@ -295,6 +321,7 @@ function hideError() {
 // -- Init ---------------------------------------------------------
 
 function initDashboard() {
+    updateSortIndicators();
     loadTrending();
     refreshTimer = setInterval(loadTrending, 30000);
 }

--- a/Application/Features/Sentiment/Queries/GetTrendingSymbols/GetTrendingSymbolsQuery.cs
+++ b/Application/Features/Sentiment/Queries/GetTrendingSymbols/GetTrendingSymbolsQuery.cs
@@ -2,5 +2,9 @@ using MediatR;
 
 namespace Application.Features.Sentiment.Queries.GetTrendingSymbols;
 
-public record GetTrendingSymbolsQuery(int Hours = 24, int Limit = 10)
+public record GetTrendingSymbolsQuery(
+    int Hours = 24,
+    int Limit = 10,
+    string? SortBy = null,
+    string? SortDirection = null)
     : IRequest<IReadOnlyList<TrendingSymbolDto>>;

--- a/Application/Features/Sentiment/Queries/GetTrendingSymbols/GetTrendingSymbolsQueryHandler.cs
+++ b/Application/Features/Sentiment/Queries/GetTrendingSymbols/GetTrendingSymbolsQueryHandler.cs
@@ -22,13 +22,36 @@ public class GetTrendingSymbolsQueryHandler(ISentimentRepository repository)
 
         var grouped = analyses.GroupBy(a => a.Symbol.Value);
 
-        var results = grouped
-            .Select(g => ComputeTrend(g.Key, g.ToList(), midpoint))
-            .OrderByDescending(t => Math.Abs(t.Delta))
+        var unordered = grouped
+            .Select(g => ComputeTrend(g.Key, g.ToList(), midpoint));
+
+        var sorted = ApplySort(unordered, query.SortBy, query.SortDirection);
+
+        var results = sorted
             .Take(query.Limit)
             .ToList();
 
         return results;
+    }
+
+    private static IOrderedEnumerable<TrendingSymbolDto> ApplySort(
+        IEnumerable<TrendingSymbolDto> items,
+        string? sortBy,
+        string? sortDirection)
+    {
+        var descending = !string.Equals(sortDirection, "asc", StringComparison.OrdinalIgnoreCase);
+
+        Func<TrendingSymbolDto, object> keySelector = sortBy?.ToLowerInvariant() switch
+        {
+            "symbol"           => t => t.Symbol,
+            "currentavgscore"  => t => t.CurrentAvgScore,
+            "previousavgscore" => t => t.PreviousAvgScore,
+            _                  => t => Math.Abs(t.Delta)  // default: delta
+        };
+
+        return descending
+            ? items.OrderByDescending(keySelector)
+            : items.OrderBy(keySelector);
     }
 
     private static TrendingSymbolDto ComputeTrend(

--- a/Tests/Application/GetTrendingSymbolsHandlerTests.cs
+++ b/Tests/Application/GetTrendingSymbolsHandlerTests.cs
@@ -211,4 +211,197 @@ public class GetTrendingSymbolsHandlerTests
             Arg.Is<DateTime>(d => d >= before && d <= after),
             Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task Handle_SortBySymbolAsc_ReturnsSortedAlphabetically()
+    {
+        var now = DateTime.UtcNow;
+        var analyses = new[]
+        {
+            MakeAnalysis("TSLA", 0.5, now.AddHours(-2)),
+            MakeAnalysis("AAPL", 0.3, now.AddHours(-2)),
+            MakeAnalysis("MSFT", 0.7, now.AddHours(-2)),
+        };
+
+        _repository.GetRecentAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(analyses);
+
+        var result = await CreateHandler().Handle(
+            new GetTrendingSymbolsQuery(24, 10, SortBy: "symbol", SortDirection: "asc"),
+            CancellationToken.None);
+
+        result.Should().HaveCount(3);
+        result[0].Symbol.Should().Be("AAPL");
+        result[1].Symbol.Should().Be("MSFT");
+        result[2].Symbol.Should().Be("TSLA");
+    }
+
+    [Fact]
+    public async Task Handle_SortBySymbolDesc_ReturnsSortedReverseAlphabetically()
+    {
+        var now = DateTime.UtcNow;
+        var analyses = new[]
+        {
+            MakeAnalysis("AAPL", 0.3, now.AddHours(-2)),
+            MakeAnalysis("TSLA", 0.5, now.AddHours(-2)),
+            MakeAnalysis("MSFT", 0.7, now.AddHours(-2)),
+        };
+
+        _repository.GetRecentAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(analyses);
+
+        var result = await CreateHandler().Handle(
+            new GetTrendingSymbolsQuery(24, 10, SortBy: "symbol", SortDirection: "desc"),
+            CancellationToken.None);
+
+        result.Should().HaveCount(3);
+        result[0].Symbol.Should().Be("TSLA");
+        result[1].Symbol.Should().Be("MSFT");
+        result[2].Symbol.Should().Be("AAPL");
+    }
+
+    [Fact]
+    public async Task Handle_SortByCurrentAvgScoreDesc_ReturnsHighestScoreFirst()
+    {
+        var now = DateTime.UtcNow;
+        var analyses = new[]
+        {
+            MakeAnalysis("AAPL", 0.3, now.AddHours(-2)),
+            MakeAnalysis("TSLA", 0.9, now.AddHours(-2)),
+            MakeAnalysis("MSFT", 0.6, now.AddHours(-2)),
+        };
+
+        _repository.GetRecentAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(analyses);
+
+        var result = await CreateHandler().Handle(
+            new GetTrendingSymbolsQuery(24, 10, SortBy: "currentAvgScore", SortDirection: "desc"),
+            CancellationToken.None);
+
+        result.Should().HaveCount(3);
+        result[0].Symbol.Should().Be("TSLA");
+        result[1].Symbol.Should().Be("MSFT");
+        result[2].Symbol.Should().Be("AAPL");
+    }
+
+    [Fact]
+    public async Task Handle_SortByCurrentAvgScoreAsc_ReturnsLowestScoreFirst()
+    {
+        var now = DateTime.UtcNow;
+        var analyses = new[]
+        {
+            MakeAnalysis("TSLA", 0.9, now.AddHours(-2)),
+            MakeAnalysis("AAPL", 0.3, now.AddHours(-2)),
+            MakeAnalysis("MSFT", 0.6, now.AddHours(-2)),
+        };
+
+        _repository.GetRecentAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(analyses);
+
+        var result = await CreateHandler().Handle(
+            new GetTrendingSymbolsQuery(24, 10, SortBy: "currentAvgScore", SortDirection: "asc"),
+            CancellationToken.None);
+
+        result.Should().HaveCount(3);
+        result[0].Symbol.Should().Be("AAPL");
+        result[1].Symbol.Should().Be("MSFT");
+        result[2].Symbol.Should().Be("TSLA");
+    }
+
+    [Fact]
+    public async Task Handle_SortByPreviousAvgScoreDesc_ReturnsHighestPrevFirst()
+    {
+        var now = DateTime.UtcNow;
+        var analyses = new[]
+        {
+            MakeAnalysis("AAPL", 0.2, now.AddHours(-20)),
+            MakeAnalysis("AAPL", 0.5, now.AddHours(-2)),
+            MakeAnalysis("TSLA", 0.8, now.AddHours(-20)),
+            MakeAnalysis("TSLA", 0.5, now.AddHours(-2)),
+            MakeAnalysis("MSFT", 0.5, now.AddHours(-20)),
+            MakeAnalysis("MSFT", 0.5, now.AddHours(-2)),
+        };
+
+        _repository.GetRecentAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(analyses);
+
+        var result = await CreateHandler().Handle(
+            new GetTrendingSymbolsQuery(24, 10, SortBy: "previousAvgScore", SortDirection: "desc"),
+            CancellationToken.None);
+
+        result.Should().HaveCount(3);
+        result[0].Symbol.Should().Be("TSLA");
+        result[1].Symbol.Should().Be("MSFT");
+        result[2].Symbol.Should().Be("AAPL");
+    }
+
+    [Fact]
+    public async Task Handle_SortByDeltaAsc_ReturnsSmallestAbsDeltaFirst()
+    {
+        var now = DateTime.UtcNow;
+
+        // AAPL: delta = +0.1, |delta| = 0.1
+        var aaplPrev    = MakeAnalysis("AAPL", 0.4, now.AddHours(-20));
+        var aaplCurrent = MakeAnalysis("AAPL", 0.5, now.AddHours(-2));
+
+        // TSLA: delta = +0.9, |delta| = 0.9
+        var tslaPrev    = MakeAnalysis("TSLA", -0.4, now.AddHours(-20));
+        var tslaCurrent = MakeAnalysis("TSLA",  0.5, now.AddHours(-2));
+
+        _repository.GetRecentAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns([aaplPrev, aaplCurrent, tslaPrev, tslaCurrent]);
+
+        var result = await CreateHandler().Handle(
+            new GetTrendingSymbolsQuery(24, 10, SortBy: "delta", SortDirection: "asc"),
+            CancellationToken.None);
+
+        result.Should().HaveCount(2);
+        result[0].Symbol.Should().Be("AAPL");
+        result[1].Symbol.Should().Be("TSLA");
+    }
+
+    [Fact]
+    public async Task Handle_DefaultSortWithNullParams_SameAsAbsDeltaDesc()
+    {
+        var now = DateTime.UtcNow;
+
+        var aaplPrev    = MakeAnalysis("AAPL", 0.4, now.AddHours(-20));
+        var aaplCurrent = MakeAnalysis("AAPL", 0.5, now.AddHours(-2));
+
+        var tslaPrev    = MakeAnalysis("TSLA", -0.4, now.AddHours(-20));
+        var tslaCurrent = MakeAnalysis("TSLA",  0.5, now.AddHours(-2));
+
+        _repository.GetRecentAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns([aaplPrev, aaplCurrent, tslaPrev, tslaCurrent]);
+
+        var result = await CreateHandler().Handle(
+            new GetTrendingSymbolsQuery(24, 10, SortBy: null, SortDirection: null),
+            CancellationToken.None);
+
+        result.Should().HaveCount(2);
+        result[0].Symbol.Should().Be("TSLA");  // |0.9| > |0.1|
+        result[1].Symbol.Should().Be("AAPL");
+    }
+
+    [Fact]
+    public async Task Handle_SortByCaseInsensitive_WorksCorrectly()
+    {
+        var now = DateTime.UtcNow;
+        var analyses = new[]
+        {
+            MakeAnalysis("TSLA", 0.9, now.AddHours(-2)),
+            MakeAnalysis("AAPL", 0.3, now.AddHours(-2)),
+        };
+
+        _repository.GetRecentAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(analyses);
+
+        var result = await CreateHandler().Handle(
+            new GetTrendingSymbolsQuery(24, 10, SortBy: "SYMBOL", SortDirection: "ASC"),
+            CancellationToken.None);
+
+        result.Should().HaveCount(2);
+        result[0].Symbol.Should().Be("AAPL");
+        result[1].Symbol.Should().Be("TSLA");
+    }
 }


### PR DESCRIPTION
## Summary
- Added `sortBy` and `sortDirection` query parameters to `GET /api/sentiment/trending`
- Valid `sortBy` values: `delta` (default), `symbol`, `currentAvgScore`, `previousAvgScore`
- Valid `sortDirection` values: `asc`, `desc` (default)
- Default behavior unchanged: sorts by absolute delta descending
- Dashboard table headers (Symbol, Score, Prev, Delta) are now clickable to toggle sort column and direction

Closes #63

## Test plan
- [x] 8 new unit tests covering all sort fields, both directions, case-insensitive params, and default behavior
- [x] All 259 tests pass
- [ ] Manual: load dashboard, click column headers, verify API calls include sortBy/sortDirection params
- [ ] Manual: verify default load still sorts by delta descending

🤖 Generated with [Claude Code](https://claude.com/claude-code)