### PR TITLE
feat: add personal watchlist

### DIFF
--- a/API/Controllers/DTOs/AddToWatchlistRequest.cs
+++ b/API/Controllers/DTOs/AddToWatchlistRequest.cs
@@ -1,0 +1,3 @@
+namespace API.Controllers.DTOs;
+
+public record AddToWatchlistRequest(string Symbol);

--- a/API/Controllers/WatchlistController.cs
+++ b/API/Controllers/WatchlistController.cs
@@ -1,0 +1,40 @@
+using API.Controllers.DTOs;
+using Application.Features.Watchlist;
+using Application.Features.Watchlist.Commands.AddToWatchlist;
+using Application.Features.Watchlist.Commands.RemoveFromWatchlist;
+using Application.Features.Watchlist.Queries.GetWatchlist;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace API.Controllers;
+
+[ApiController]
+[Route("api/watchlist")]
+public class WatchlistController(ISender sender) : ControllerBase
+{
+    [HttpGet]
+    [ProducesResponseType(typeof(IReadOnlyList<WatchlistSymbolDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetWatchlist(CancellationToken ct)
+    {
+        var result = await sender.Send(new GetWatchlistQuery(), ct);
+        return Ok(result);
+    }
+
+    [HttpPost]
+    [ProducesResponseType(typeof(WatchlistSymbolDto), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Add([FromBody] AddToWatchlistRequest request, CancellationToken ct)
+    {
+        var result = await sender.Send(new AddToWatchlistCommand(request.Symbol), ct);
+        return CreatedAtAction(nameof(GetWatchlist), result);
+    }
+
+    [HttpDelete("{symbol}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Remove(string symbol, CancellationToken ct)
+    {
+        await sender.Send(new RemoveFromWatchlistCommand(symbol), ct);
+        return NoContent();
+    }
+}

--- a/API/appsettings.json
+++ b/API/appsettings.json
@@ -35,8 +35,8 @@
     "TimeoutSeconds": 30
   },
   "SentimentScoring": {
-    "HalfLifeHours": 72,
-    "DefaultWindowDays": 7,
+    "HalfLifeHours": 36,
+    "DefaultWindowDays": 14,
     "MaxDataAgeDays": 30
   },
   "Ingestion": {

--- a/API/appsettings.json
+++ b/API/appsettings.json
@@ -34,6 +34,11 @@
     "BaseUrl": "",
     "TimeoutSeconds": 30
   },
+  "SentimentScoring": {
+    "HalfLifeHours": 72,
+    "DefaultWindowDays": 7,
+    "MaxDataAgeDays": 30
+  },
   "Ingestion": {
     "TrackedSymbols": [ "AAPL", "MSFT", "GOOGL", "TSLA", "NVDA", "AMZN", "META", "NFLX", "AMD", "INTC", "JPM", "BAC", "SPY", "QQQ", "BTC-USD" ],
     "SeedGroups": [ "crypto", "us-bluechip", "asx-bluechip", "tech", "etfs" ],

--- a/API/wwwroot/css/dashboard.css
+++ b/API/wwwroot/css/dashboard.css
@@ -419,6 +419,99 @@ tbody tr:hover {
 
 .error-banner.visible { display: block; }
 
+/* Watchlist */
+.watchlist-card {
+    margin-bottom: 24px;
+}
+
+.watchlist-add {
+    display: flex;
+    gap: 8px;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border);
+    background: var(--surface2);
+}
+
+.watchlist-add input {
+    flex: 1;
+    max-width: 220px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 6px 12px;
+    color: var(--text);
+    font-size: 0.85rem;
+    outline: none;
+}
+
+.watchlist-add input:focus {
+    border-color: var(--blue);
+}
+
+.watchlist-add button {
+    background: var(--blue);
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    padding: 6px 16px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.watchlist-add button:hover {
+    opacity: 0.9;
+}
+
+.watchlist-add button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.watchlist-error {
+    display: none;
+    padding: 8px 16px;
+    font-size: 0.8rem;
+    color: var(--red);
+    background: rgba(255,92,92,0.08);
+}
+
+.watchlist-error.visible {
+    display: block;
+}
+
+.remove-btn {
+    background: none;
+    border: none;
+    color: var(--red);
+    font-size: 1.1rem;
+    cursor: pointer;
+    padding: 0 4px;
+    opacity: 0.6;
+}
+
+.remove-btn:hover {
+    opacity: 1;
+}
+
+.watchlist-plus-btn {
+    background: none;
+    border: 1px solid var(--border);
+    color: var(--blue);
+    font-size: 0.85rem;
+    font-weight: 700;
+    cursor: pointer;
+    padding: 1px 7px;
+    border-radius: 4px;
+    margin-left: 8px;
+    vertical-align: middle;
+}
+
+.watchlist-plus-btn:hover {
+    background: var(--surface2);
+    border-color: var(--blue);
+}
+
 /* Admin Page */
 .admin-grid {
     display: grid;

--- a/API/wwwroot/index.html
+++ b/API/wwwroot/index.html
@@ -43,6 +43,32 @@
                 <div class="history-list" id="historyList"></div>
             </div>
 
+            <!-- My Watchlist -->
+            <p class="section-title">My Watchlist</p>
+            <div class="card watchlist-card">
+                <div class="watchlist-add">
+                    <input type="text" id="watchlistInput" placeholder="Add symbol (e.g. GOOG)" maxlength="10" />
+                    <button id="watchlistAddBtn" onclick="addToWatchlist()">Add</button>
+                </div>
+                <div class="watchlist-error" id="watchlistError"></div>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Symbol</th>
+                            <th>Score</th>
+                            <th>Trend</th>
+                            <th>Dispersion</th>
+                            <th>Articles</th>
+                            <th></th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody id="watchlistBody">
+                        <tr><td colspan="7" class="empty-state">Loading...</td></tr>
+                    </tbody>
+                </table>
+            </div>
+
             <!-- Trending Table -->
             <p class="section-title">Trending Symbols (24h)</p>
             <div class="card">

--- a/API/wwwroot/js/dashboard.js
+++ b/API/wwwroot/js/dashboard.js
@@ -128,7 +128,8 @@ function renderTrending(items) {
             <td style="color:${trendColor}">${t.trend}</td>
             <td>${t.dispersion.toFixed(3)}</td>
             <td>${t.articleCount}</td>
-            <td><a href="${detailUrl}" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()" title="View on Yahoo Finance" style="color:var(--blue, #5b8def);text-decoration:none;font-size:0.85rem">&#x2197;</a></td>
+            <td><a href="${detailUrl}" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()" title="View on Yahoo Finance" style="color:var(--blue, #5b8def);text-decoration:none;font-size:0.85rem">&#x2197;</a>
+                <button class="watchlist-plus-btn" onclick="event.stopPropagation(); addToWatchlist('${t.symbol}')" title="Add to watchlist">+</button></td>
         </tr>`;
     }).join('');
 }
@@ -352,10 +353,98 @@ function hideError() {
     document.getElementById('errorBanner').classList.remove('visible');
 }
 
+// -- Watchlist ----------------------------------------------------
+
+async function loadWatchlist() {
+    try {
+        const res = await fetch(`${API}/api/watchlist`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+        renderWatchlist(data);
+    } catch (e) {
+        const tbody = document.getElementById('watchlistBody');
+        tbody.innerHTML = '<tr><td colspan="7" class="empty-state">Failed to load watchlist</td></tr>';
+    }
+}
+
+function renderWatchlist(items) {
+    const tbody = document.getElementById('watchlistBody');
+    if (!items.length) {
+        tbody.innerHTML = '<tr><td colspan="7" class="empty-state">No symbols in your watchlist. Add one above or click + on a trending symbol.</td></tr>';
+        return;
+    }
+    tbody.innerHTML = items.map(w => {
+        const scoreClass = w.score > 0.1 ? 'positive' : w.score < -0.1 ? 'negative' : 'neutral';
+        const trendColor = w.trend === 'Improving' ? 'var(--green)' :
+                           w.trend === 'Deteriorating' ? 'var(--red)' : 'var(--text-dim)';
+        const yahooUrl = `https://finance.yahoo.com/quote/${encodeURIComponent(w.symbol)}/`;
+        return `<tr onclick="openDetail('${w.symbol}')" style="cursor:pointer">
+            <td><strong>${w.symbol}</strong></td>
+            <td class="score ${scoreClass}">${w.score.toFixed(3)}</td>
+            <td style="color:${trendColor}">${w.trend}</td>
+            <td>${w.dispersion.toFixed(3)}</td>
+            <td>${w.articleCount}</td>
+            <td><a href="${yahooUrl}" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()" title="View on Yahoo Finance" style="color:var(--blue, #5b8def);text-decoration:none;font-size:0.85rem">&#x2197;</a></td>
+            <td><button class="remove-btn" onclick="event.stopPropagation(); removeFromWatchlist('${w.symbol}')" title="Remove from watchlist">&times;</button></td>
+        </tr>`;
+    }).join('');
+}
+
+async function addToWatchlist(symbol) {
+    const input = document.getElementById('watchlistInput');
+    const errorEl = document.getElementById('watchlistError');
+    const btn = document.getElementById('watchlistAddBtn');
+    const sym = symbol || input.value.trim().toUpperCase();
+
+    if (!sym) return;
+
+    errorEl.textContent = '';
+    errorEl.classList.remove('visible');
+    btn.disabled = true;
+    btn.textContent = '...';
+
+    try {
+        const res = await fetch(`${API}/api/watchlist`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ symbol: sym })
+        });
+
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({ detail: `HTTP ${res.status}` }));
+            throw new Error(err.detail || err.title || `HTTP ${res.status}`);
+        }
+
+        input.value = '';
+        loadWatchlist();
+    } catch (e) {
+        errorEl.textContent = e.message;
+        errorEl.classList.add('visible');
+    } finally {
+        btn.disabled = false;
+        btn.textContent = 'Add';
+    }
+}
+
+async function removeFromWatchlist(symbol) {
+    try {
+        await fetch(`${API}/api/watchlist/${encodeURIComponent(symbol)}`, { method: 'DELETE' });
+        loadWatchlist();
+    } catch (e) {
+        // Silently fail — next refresh will correct
+    }
+}
+
 // -- Init ---------------------------------------------------------
 
 function initDashboard() {
     updateSortIndicators();
     loadTrending();
-    refreshTimer = setInterval(loadTrending, 30000);
+    loadWatchlist();
+    refreshTimer = setInterval(() => { loadTrending(); loadWatchlist(); }, 30000);
+
+    // Enter key on watchlist input
+    document.getElementById('watchlistInput').addEventListener('keydown', e => {
+        if (e.key === 'Enter') addToWatchlist();
+    });
 }

--- a/Application/Configuration/SentimentScoringOptions.cs
+++ b/Application/Configuration/SentimentScoringOptions.cs
@@ -1,0 +1,19 @@
+namespace Application.Configuration;
+
+/// <summary>
+/// Configurable parameters for decay-weighted sentiment scoring.
+/// Bound from appsettings "SentimentScoring" section.
+/// </summary>
+public class SentimentScoringOptions
+{
+    public const string SectionName = "SentimentScoring";
+
+    /// <summary>Hours for an article's weight to halve (default 72 = 3 days).</summary>
+    public int HalfLifeHours { get; init; } = 72;
+
+    /// <summary>Default data window in days for trending/watchlist/snapshots.</summary>
+    public int DefaultWindowDays { get; init; } = 7;
+
+    /// <summary>Maximum data age in days for stats queries.</summary>
+    public int MaxDataAgeDays { get; init; } = 30;
+}

--- a/Application/Configuration/SentimentScoringOptions.cs
+++ b/Application/Configuration/SentimentScoringOptions.cs
@@ -8,11 +8,11 @@ public class SentimentScoringOptions
 {
     public const string SectionName = "SentimentScoring";
 
-    /// <summary>Hours for an article's weight to halve (default 72 = 3 days).</summary>
-    public int HalfLifeHours { get; init; } = 72;
+    /// <summary>Hours for an article's weight to halve (default 36 = 1.5 days).</summary>
+    public int HalfLifeHours { get; init; } = 36;
 
     /// <summary>Default data window in days for trending/watchlist/snapshots.</summary>
-    public int DefaultWindowDays { get; init; } = 7;
+    public int DefaultWindowDays { get; init; } = 14;
 
     /// <summary>Maximum data age in days for stats queries.</summary>
     public int MaxDataAgeDays { get; init; } = 30;

--- a/Application/Features/Sentiment/Commands/AnalyzeSentiment/RefreshSnapshotHandler.cs
+++ b/Application/Features/Sentiment/Commands/AnalyzeSentiment/RefreshSnapshotHandler.cs
@@ -38,14 +38,14 @@ public class RefreshSnapshotHandler(
             if (existing is not null)
             {
                 existing.Update(stats.Score, stats.PreviousScore, stats.Delta,
-                    stats.Direction, stats.Trend, stats.Dispersion, stats.ArticleCount);
+                    stats.Direction, stats.Trend.Direction, stats.Dispersion, stats.ArticleCount);
                 await snapshotRepository.UpsertAsync(existing, ct);
             }
             else
             {
                 var snapshot = SymbolSnapshot.Create(
                     symbol, stats.Score, stats.PreviousScore, stats.Delta,
-                    stats.Direction, stats.Trend, stats.Dispersion, stats.ArticleCount);
+                    stats.Direction, stats.Trend.Direction, stats.Dispersion, stats.ArticleCount);
                 await snapshotRepository.UpsertAsync(snapshot, ct);
             }
         }

--- a/Application/Features/Sentiment/Commands/AnalyzeSentiment/RefreshSnapshotHandler.cs
+++ b/Application/Features/Sentiment/Commands/AnalyzeSentiment/RefreshSnapshotHandler.cs
@@ -1,3 +1,4 @@
+using Application.Configuration;
 using Domain.Entities;
 using Domain.Interfaces;
 using Domain.ValueObjects;
@@ -13,10 +14,10 @@ namespace Application.Features.Sentiment.Commands.AnalyzeSentiment;
 public class RefreshSnapshotHandler(
     ISentimentRepository sentimentRepository,
     ISymbolSnapshotRepository snapshotRepository,
+    SentimentScoringOptions scoringOptions,
     ILogger<RefreshSnapshotHandler> logger)
     : INotificationHandler<SentimentAnalysisCreatedNotification>
 {
-    private const int DataWindowDays = 7;
 
     public async Task Handle(SentimentAnalysisCreatedNotification notification, CancellationToken ct)
     {
@@ -25,10 +26,12 @@ public class RefreshSnapshotHandler(
             var symbol = notification.Symbol;
             var now = DateTime.UtcNow;
 
+            var config = scoringOptions;
             var analyses = await sentimentRepository.GetForStatsAsync(
-                new StockSymbol(symbol), DataWindowDays, ct);
+                new StockSymbol(symbol), config.DefaultWindowDays, ct);
 
-            var stats = SentimentMath.ComputeSymbolStats(analyses, now, DataWindowDays * 24);
+            var stats = SentimentMath.ComputeSymbolStats(
+                analyses, now, config.DefaultWindowDays * 24, config.HalfLifeHours);
 
             var existing = await snapshotRepository.GetBySymbolAsync(symbol, ct);
 

--- a/Application/Features/Sentiment/Commands/AnalyzeSentiment/RefreshSnapshotHandler.cs
+++ b/Application/Features/Sentiment/Commands/AnalyzeSentiment/RefreshSnapshotHandler.cs
@@ -1,0 +1,72 @@
+using Domain.Entities;
+using Domain.Interfaces;
+using Domain.ValueObjects;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Features.Sentiment.Commands.AnalyzeSentiment;
+
+/// <summary>
+/// Recomputes the SymbolSnapshot after each new analysis is persisted.
+/// This materializes decay-weighted stats so GET endpoints read precomputed data.
+/// </summary>
+public class RefreshSnapshotHandler(
+    ISentimentRepository sentimentRepository,
+    ISymbolSnapshotRepository snapshotRepository,
+    ILogger<RefreshSnapshotHandler> logger)
+    : INotificationHandler<SentimentAnalysisCreatedNotification>
+{
+    private const int DataWindowDays = 7;
+
+    public async Task Handle(SentimentAnalysisCreatedNotification notification, CancellationToken ct)
+    {
+        try
+        {
+            var symbol = notification.Symbol;
+            var now = DateTime.UtcNow;
+            var midpoint = now.AddDays(-DataWindowDays / 2.0);
+
+            var analyses = await sentimentRepository.GetForStatsAsync(
+                new StockSymbol(symbol), DataWindowDays, ct);
+
+            var current = analyses.Where(a => a.AnalyzedAt >= midpoint).ToList();
+            var previous = analyses.Where(a => a.AnalyzedAt < midpoint).ToList();
+
+            var currentAvg = Math.Round(SentimentMath.DecayWeightedAverage(current, now), 4);
+            var previousAvg = Math.Round(SentimentMath.DecayWeightedAverage(previous, midpoint), 4);
+            var delta = Math.Round(currentAvg - previousAvg, 4);
+
+            var direction = delta switch
+            {
+                > 0 => "up",
+                < 0 => "down",
+                _ => "flat"
+            };
+
+            var trend = SentimentMath.CalculateTrendDirection(analyses);
+            var dispersion = SentimentMath.CalculateDispersion(analyses, now);
+
+            var existing = await snapshotRepository.GetBySymbolAsync(symbol, ct);
+
+            if (existing is not null)
+            {
+                existing.Update(currentAvg, previousAvg, delta, direction, trend, dispersion, analyses.Count);
+                await snapshotRepository.UpsertAsync(existing, ct);
+            }
+            else
+            {
+                var snapshot = SymbolSnapshot.Create(
+                    symbol, currentAvg, previousAvg, delta, direction, trend, dispersion, analyses.Count);
+                await snapshotRepository.UpsertAsync(snapshot, ct);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Shutting down — don't log as warning
+        }
+        catch (InvalidOperationException ex)
+        {
+            logger.LogWarning(ex, "Failed to refresh snapshot for {Symbol}", notification.Symbol);
+        }
+    }
+}

--- a/Application/Features/Sentiment/Commands/AnalyzeSentiment/RefreshSnapshotHandler.cs
+++ b/Application/Features/Sentiment/Commands/AnalyzeSentiment/RefreshSnapshotHandler.cs
@@ -24,39 +24,25 @@ public class RefreshSnapshotHandler(
         {
             var symbol = notification.Symbol;
             var now = DateTime.UtcNow;
-            var midpoint = now.AddDays(-DataWindowDays / 2.0);
 
             var analyses = await sentimentRepository.GetForStatsAsync(
                 new StockSymbol(symbol), DataWindowDays, ct);
 
-            var current = analyses.Where(a => a.AnalyzedAt >= midpoint).ToList();
-            var previous = analyses.Where(a => a.AnalyzedAt < midpoint).ToList();
-
-            var currentAvg = Math.Round(SentimentMath.DecayWeightedAverage(current, now), 4);
-            var previousAvg = Math.Round(SentimentMath.DecayWeightedAverage(previous, midpoint), 4);
-            var delta = Math.Round(currentAvg - previousAvg, 4);
-
-            var direction = delta switch
-            {
-                > 0 => "up",
-                < 0 => "down",
-                _ => "flat"
-            };
-
-            var trend = SentimentMath.CalculateTrendDirection(analyses);
-            var dispersion = SentimentMath.CalculateDispersion(analyses, now);
+            var stats = SentimentMath.ComputeSymbolStats(analyses, now, DataWindowDays * 24);
 
             var existing = await snapshotRepository.GetBySymbolAsync(symbol, ct);
 
             if (existing is not null)
             {
-                existing.Update(currentAvg, previousAvg, delta, direction, trend, dispersion, analyses.Count);
+                existing.Update(stats.Score, stats.PreviousScore, stats.Delta,
+                    stats.Direction, stats.Trend, stats.Dispersion, stats.ArticleCount);
                 await snapshotRepository.UpsertAsync(existing, ct);
             }
             else
             {
                 var snapshot = SymbolSnapshot.Create(
-                    symbol, currentAvg, previousAvg, delta, direction, trend, dispersion, analyses.Count);
+                    symbol, stats.Score, stats.PreviousScore, stats.Delta,
+                    stats.Direction, stats.Trend, stats.Dispersion, stats.ArticleCount);
                 await snapshotRepository.UpsertAsync(snapshot, ct);
             }
         }

--- a/Application/Features/Sentiment/Commands/AnalyzeSentiment/RefreshSnapshotHandler.cs
+++ b/Application/Features/Sentiment/Commands/AnalyzeSentiment/RefreshSnapshotHandler.cs
@@ -31,7 +31,7 @@ public class RefreshSnapshotHandler(
                 new StockSymbol(symbol), config.DefaultWindowDays, ct);
 
             var stats = SentimentMath.ComputeSymbolStats(
-                analyses, now, config.DefaultWindowDays * 24, config.HalfLifeHours);
+                analyses, now, config.DefaultWindowDays * 24.0, config.HalfLifeHours);
 
             var existing = await snapshotRepository.GetBySymbolAsync(symbol, ct);
 

--- a/Application/Features/Sentiment/Queries/GetSentimentStats/GetSentimentStatsQueryHandler.cs
+++ b/Application/Features/Sentiment/Queries/GetSentimentStats/GetSentimentStatsQueryHandler.cs
@@ -17,192 +17,79 @@ public class GetSentimentStatsQueryHandler(
     {
         var symbol = new StockSymbol(query.Symbol);
         var days = Math.Min(query.Days, scoringOptions.MaxDataAgeDays);
-
         var analyses = await repository.GetForStatsAsync(symbol, days, ct);
 
         if (analyses.Count == 0)
             throw new NotFoundException("SentimentAnalysis", $"symbol={query.Symbol}, days={days}");
 
         var now = DateTime.UtcNow;
-        var from = now.AddDays(-days);
         var halfLifeHours = query.HalfLifeHours > 0 ? query.HalfLifeHours : scoringOptions.HalfLifeHours;
 
-        // Compute time-decay weights for each analysis
-        var weighted = analyses.Select(a =>
-        {
-            var ageHours = (now - a.AnalyzedAt).TotalHours;
-            var weight = Math.Exp(-Math.Log(2) / halfLifeHours * ageHours);
-            return (Analysis: a, Weight: weight);
-        }).ToList();
+        var weightedScore = Math.Round(SentimentMath.DecayWeightedAverage(analyses, now, halfLifeHours), 4);
+        var dispersion = SentimentMath.CalculateDispersion(analyses, now, halfLifeHours);
+        var totalWeight = SentimentMath.TotalDecayWeight(analyses, now, halfLifeHours);
+        var signalStrength = SentimentMath.ClassifySignalStrength(totalWeight);
+        var trend = SentimentMath.CalculateTrend(analyses);
+        var shift = SentimentMath.ComputeSentimentShift(analyses, now, halfLifeHours);
 
-        var totalWeight = weighted.Sum(w => w.Weight);
-
-        // Exponential decay weighted average score
-        var weightedScore = totalWeight > 0
-            ? Math.Round(weighted.Sum(w => w.Weight * w.Analysis.Score.Value) / totalWeight, 4)
-            : 0.0;
-
-        // Dispersion: weighted standard deviation
-        var dispersion = totalWeight > 0
-            ? Math.Round(Math.Sqrt(
-                weighted.Sum(w => w.Weight * Math.Pow(w.Analysis.Score.Value - weightedScore, 2)) / totalWeight), 4)
-            : 0.0;
-
-        // Signal strength based on total weight
-        var signalStrength = totalWeight switch
-        {
-            >= 3.0 => "strong",
-            >= 1.0 => "moderate",
-            _      => "no signal"
-        };
-
-        var avgConf = Math.Round(analyses.Average(a => a.Confidence), 4);
-
-        // Distribution
-        var total = analyses.Count;
-        var positiveCount = analyses.Count(a => a.Label == SentimentLabel.Positive);
-        var neutralCount  = analyses.Count(a => a.Label == SentimentLabel.Neutral);
-        var negativeCount = analyses.Count(a => a.Label == SentimentLabel.Negative);
-
-        var distribution = new SentimentDistribution(
-            PositivePercent: Math.Round((double)positiveCount / total * 100, 1),
-            NeutralPercent:  Math.Round((double)neutralCount  / total * 100, 1),
-            NegativePercent: Math.Round((double)negativeCount / total * 100, 1));
-
-        var trend = CalculateTrend(analyses);
+        var distribution = SentimentMath.ComputeDistribution(analyses);
 
         var highest = analyses.MaxBy(a => a.Score.Value)!;
-        var lowest  = analyses.MinBy(a => a.Score.Value)!;
-        var latest  = analyses.MaxBy(a => a.AnalyzedAt)!;
+        var lowest = analyses.MinBy(a => a.Score.Value)!;
+        var latest = analyses.MaxBy(a => a.AnalyzedAt)!;
 
-        // Most recent article
         var mostRecent = new ArticleContext(
             Headline: TruncateToHeadline(latest.OriginalText),
             Score: latest.Score.Value,
             AnalyzedAt: latest.AnalyzedAt);
 
-        // Most impactful article (highest weight × |score|)
-        var mostImpactful = weighted
-            .OrderByDescending(w => w.Weight * Math.Abs(w.Analysis.Score.Value))
-            .First();
-        var impactfulDto = new ImpactfulArticle(
-            Headline: TruncateToHeadline(mostImpactful.Analysis.OriginalText),
-            Score: mostImpactful.Analysis.Score.Value,
-            Weight: Math.Round(mostImpactful.Weight, 4),
-            AnalyzedAt: mostImpactful.Analysis.AnalyzedAt);
-
-        // Sentiment shift: compare current weighted score to 24h ago and 7d ago
-        var shift = ComputeSentimentShift(weighted, now, halfLifeHours);
+        var impactful = SentimentMath.MostImpactful(analyses, now, halfLifeHours);
+        var impactfulDto = impactful is not null
+            ? new ImpactfulArticle(
+                Headline: TruncateToHeadline(impactful.Value.Analysis.OriginalText),
+                Score: impactful.Value.Analysis.Score.Value,
+                Weight: Math.Round(impactful.Value.Weight, 4),
+                AnalyzedAt: impactful.Value.Analysis.AnalyzedAt)
+            : null;
 
         return new SentimentStatsDto(
-            Symbol:              symbol.Value,
-            Period:              new StatsPeriod(from, now, days),
-            TotalAnalyses:       total,
-            WeightedScore:       weightedScore,
-            AverageConfidence:   avgConf,
-            SignalStrength:      signalStrength,
-            Dispersion:          dispersion,
-            HalfLifeHours:       halfLifeHours,
-            Distribution:        distribution,
-            Trend:               trend,
-            HighestScore:        new ScoreDataPoint(highest.Score.Value, highest.AnalyzedAt),
-            LowestScore:         new ScoreDataPoint(lowest.Score.Value,  lowest.AnalyzedAt),
-            LatestScore:         latest.Score.Value,
-            MostRecentArticle:   mostRecent,
+            Symbol: symbol.Value,
+            Period: new StatsPeriod(now.AddDays(-days), now, days),
+            TotalAnalyses: analyses.Count,
+            WeightedScore: weightedScore,
+            AverageConfidence: Math.Round(analyses.Average(a => a.Confidence), 4),
+            SignalStrength: signalStrength,
+            Dispersion: dispersion,
+            HalfLifeHours: halfLifeHours,
+            Distribution: distribution,
+            Trend: new SentimentTrend(trend.Direction, trend.Slope),
+            HighestScore: new ScoreDataPoint(highest.Score.Value, highest.AnalyzedAt),
+            LowestScore: new ScoreDataPoint(lowest.Score.Value, lowest.AnalyzedAt),
+            LatestScore: latest.Score.Value,
+            MostRecentArticle: mostRecent,
             MostImpactfulArticle: impactfulDto,
-            SentimentShift:      shift);
+            SentimentShift: new SentimentShift(shift.Vs24h, shift.Vs7d));
     }
 
-    private static SentimentShift ComputeSentimentShift(
-        List<(SentimentAnalysis Analysis, double Weight)> weighted,
-        DateTime now,
-        int halfLifeHours)
+    private static SentimentDistribution ComputeDistribution(IReadOnlyList<SentimentAnalysis> analyses)
     {
-        var vs24h = ComputeWeightedScoreAt(weighted, now.AddHours(-24), halfLifeHours);
-        var vs7d  = ComputeWeightedScoreAt(weighted, now.AddDays(-7), halfLifeHours);
+        var total = analyses.Count;
+        var positive = analyses.Count(a => a.Label == SentimentLabel.Positive);
+        var neutral = analyses.Count(a => a.Label == SentimentLabel.Neutral);
+        var negative = analyses.Count(a => a.Label == SentimentLabel.Negative);
 
-        var currentScore = weighted.Sum(w => w.Weight) > 0
-            ? weighted.Sum(w => w.Weight * w.Analysis.Score.Value) / weighted.Sum(w => w.Weight)
-            : (double?)null;
-
-        return new SentimentShift(
-            Vs24h: currentScore.HasValue && vs24h.HasValue
-                ? Math.Round(currentScore.Value - vs24h.Value, 4)
-                : null,
-            Vs7d: currentScore.HasValue && vs7d.HasValue
-                ? Math.Round(currentScore.Value - vs7d.Value, 4)
-                : null);
-    }
-
-    private static double? ComputeWeightedScoreAt(
-        List<(SentimentAnalysis Analysis, double Weight)> allWeighted,
-        DateTime asOf,
-        int halfLifeHours)
-    {
-        // Only include articles that existed at the reference time
-        var subset = allWeighted
-            .Where(w => w.Analysis.AnalyzedAt <= asOf)
-            .Select(w =>
-            {
-                var ageHours = (asOf - w.Analysis.AnalyzedAt).TotalHours;
-                var weight = Math.Exp(-Math.Log(2) / halfLifeHours * ageHours);
-                return (w.Analysis, Weight: weight);
-            })
-            .ToList();
-
-        if (subset.Count == 0)
-            return null;
-
-        var totalWeight = subset.Sum(w => w.Weight);
-        return totalWeight > 0
-            ? subset.Sum(w => w.Weight * w.Analysis.Score.Value) / totalWeight
-            : null;
+        return new SentimentDistribution(
+            PositivePercent: Math.Round((double)positive / total * 100, 1),
+            NeutralPercent: Math.Round((double)neutral / total * 100, 1),
+            NegativePercent: Math.Round((double)negative / total * 100, 1));
     }
 
     private static string TruncateToHeadline(string text)
     {
-        // Take first sentence or first 100 chars, whichever is shorter
         var firstSentenceEnd = text.IndexOfAny(['.', '!', '?']);
         if (firstSentenceEnd > 0 && firstSentenceEnd < 150)
             return text[..(firstSentenceEnd + 1)];
 
         return text.Length <= 100 ? text : text[..100] + "...";
-    }
-
-    /// <summary>
-    /// Linear regression over (day-offset, score) pairs.
-    /// Slope > 0 = improving sentiment over time; slope &lt; 0 = deteriorating.
-    /// </summary>
-    private static SentimentTrend CalculateTrend(IReadOnlyList<SentimentAnalysis> analyses)
-    {
-        if (analyses.Count < 2)
-            return new SentimentTrend("Stable", 0);
-
-        var origin = analyses.Min(a => a.AnalyzedAt);
-        var points = analyses
-            .Select(a => ((a.AnalyzedAt - origin).TotalDays, a.Score.Value))
-            .ToList();
-
-        var n    = points.Count;
-        var sumX = points.Sum(p => p.Item1);
-        var sumY = points.Sum(p => p.Item2);
-        var sumXY = points.Sum(p => p.Item1 * p.Item2);
-        var sumX2 = points.Sum(p => p.Item1 * p.Item1);
-
-        var denominator = n * sumX2 - sumX * sumX;
-        if (Math.Abs(denominator) < double.Epsilon)
-            return new SentimentTrend("Stable", 0);
-
-        var slope = (n * sumXY - sumX * sumY) / denominator;
-        var roundedSlope = Math.Round(slope, 4);
-
-        var direction = roundedSlope switch
-        {
-            > 0.005  => "Improving",
-            < -0.005 => "Deteriorating",
-            _        => "Stable"
-        };
-
-        return new SentimentTrend(direction, roundedSlope);
     }
 }

--- a/Application/Features/Sentiment/Queries/GetSentimentStats/GetSentimentStatsQueryHandler.cs
+++ b/Application/Features/Sentiment/Queries/GetSentimentStats/GetSentimentStatsQueryHandler.cs
@@ -1,7 +1,5 @@
 using Application.Configuration;
 using Application.Exceptions;
-using Domain.Enums;
-using Domain.Entities;
 using Domain.Interfaces;
 using Domain.ValueObjects;
 using MediatR;
@@ -25,14 +23,7 @@ public class GetSentimentStatsQueryHandler(
         var now = DateTime.UtcNow;
         var halfLifeHours = query.HalfLifeHours > 0 ? query.HalfLifeHours : scoringOptions.HalfLifeHours;
 
-        var weightedScore = Math.Round(SentimentMath.DecayWeightedAverage(analyses, now, halfLifeHours), 4);
-        var dispersion = SentimentMath.CalculateDispersion(analyses, now, halfLifeHours);
-        var totalWeight = SentimentMath.TotalDecayWeight(analyses, now, halfLifeHours);
-        var signalStrength = SentimentMath.ClassifySignalStrength(totalWeight);
-        var trend = SentimentMath.CalculateTrend(analyses);
-        var shift = SentimentMath.ComputeSentimentShift(analyses, now, halfLifeHours);
-
-        var distribution = SentimentMath.ComputeDistribution(analyses);
+        var stats = SentimentMath.ComputeSymbolStats(analyses, now, days * 24.0, halfLifeHours);
 
         var highest = analyses.MaxBy(a => a.Score.Value)!;
         var lowest = analyses.MinBy(a => a.Score.Value)!;
@@ -43,45 +34,31 @@ public class GetSentimentStatsQueryHandler(
             Score: latest.Score.Value,
             AnalyzedAt: latest.AnalyzedAt);
 
-        var impactful = SentimentMath.MostImpactful(analyses, now, halfLifeHours);
-        var impactfulDto = impactful is not null
+        var impactfulDto = stats.MostImpactful is not null
             ? new ImpactfulArticle(
-                Headline: TruncateToHeadline(impactful.Value.Analysis.OriginalText),
-                Score: impactful.Value.Analysis.Score.Value,
-                Weight: Math.Round(impactful.Value.Weight, 4),
-                AnalyzedAt: impactful.Value.Analysis.AnalyzedAt)
+                Headline: TruncateToHeadline(stats.MostImpactful.Value.Analysis.OriginalText),
+                Score: stats.MostImpactful.Value.Analysis.Score.Value,
+                Weight: Math.Round(stats.MostImpactful.Value.Weight, 4),
+                AnalyzedAt: stats.MostImpactful.Value.Analysis.AnalyzedAt)
             : null;
 
         return new SentimentStatsDto(
             Symbol: symbol.Value,
             Period: new StatsPeriod(now.AddDays(-days), now, days),
-            TotalAnalyses: analyses.Count,
-            WeightedScore: weightedScore,
+            TotalAnalyses: stats.ArticleCount,
+            WeightedScore: stats.Score,
             AverageConfidence: Math.Round(analyses.Average(a => a.Confidence), 4),
-            SignalStrength: signalStrength,
-            Dispersion: dispersion,
+            SignalStrength: stats.SignalStrength,
+            Dispersion: stats.Dispersion,
             HalfLifeHours: halfLifeHours,
-            Distribution: distribution,
-            Trend: new SentimentTrend(trend.Direction, trend.Slope),
+            Distribution: stats.Distribution,
+            Trend: new SentimentTrend(stats.Trend.Direction, stats.Trend.Slope),
             HighestScore: new ScoreDataPoint(highest.Score.Value, highest.AnalyzedAt),
             LowestScore: new ScoreDataPoint(lowest.Score.Value, lowest.AnalyzedAt),
             LatestScore: latest.Score.Value,
             MostRecentArticle: mostRecent,
             MostImpactfulArticle: impactfulDto,
-            SentimentShift: new SentimentShift(shift.Vs24h, shift.Vs7d));
-    }
-
-    private static SentimentDistribution ComputeDistribution(IReadOnlyList<SentimentAnalysis> analyses)
-    {
-        var total = analyses.Count;
-        var positive = analyses.Count(a => a.Label == SentimentLabel.Positive);
-        var neutral = analyses.Count(a => a.Label == SentimentLabel.Neutral);
-        var negative = analyses.Count(a => a.Label == SentimentLabel.Negative);
-
-        return new SentimentDistribution(
-            PositivePercent: Math.Round((double)positive / total * 100, 1),
-            NeutralPercent: Math.Round((double)neutral / total * 100, 1),
-            NegativePercent: Math.Round((double)negative / total * 100, 1));
+            SentimentShift: new SentimentShift(stats.Shift.Vs24h, stats.Shift.Vs7d));
     }
 
     private static string TruncateToHeadline(string text)

--- a/Application/Features/Sentiment/Queries/GetSentimentStats/GetSentimentStatsQueryHandler.cs
+++ b/Application/Features/Sentiment/Queries/GetSentimentStats/GetSentimentStatsQueryHandler.cs
@@ -1,3 +1,4 @@
+using Application.Configuration;
 using Application.Exceptions;
 using Domain.Enums;
 using Domain.Entities;
@@ -7,15 +8,15 @@ using MediatR;
 
 namespace Application.Features.Sentiment.Queries.GetSentimentStats;
 
-public class GetSentimentStatsQueryHandler(ISentimentRepository repository)
+public class GetSentimentStatsQueryHandler(
+    ISentimentRepository repository,
+    SentimentScoringOptions scoringOptions)
     : IRequestHandler<GetSentimentStatsQuery, SentimentStatsDto>
 {
-    private const int MaxDataAgeDays = 30;
-
     public async Task<SentimentStatsDto> Handle(GetSentimentStatsQuery query, CancellationToken ct)
     {
         var symbol = new StockSymbol(query.Symbol);
-        var days = Math.Min(query.Days, MaxDataAgeDays);
+        var days = Math.Min(query.Days, scoringOptions.MaxDataAgeDays);
 
         var analyses = await repository.GetForStatsAsync(symbol, days, ct);
 
@@ -24,7 +25,7 @@ public class GetSentimentStatsQueryHandler(ISentimentRepository repository)
 
         var now = DateTime.UtcNow;
         var from = now.AddDays(-days);
-        var halfLifeHours = query.HalfLifeHours;
+        var halfLifeHours = query.HalfLifeHours > 0 ? query.HalfLifeHours : scoringOptions.HalfLifeHours;
 
         // Compute time-decay weights for each analysis
         var weighted = analyses.Select(a =>

--- a/Application/Features/Sentiment/Queries/GetSentimentStats/SentimentStatsDto.cs
+++ b/Application/Features/Sentiment/Queries/GetSentimentStats/SentimentStatsDto.cs
@@ -1,3 +1,5 @@
+using Application.Features.Sentiment;
+
 namespace Application.Features.Sentiment.Queries.GetSentimentStats;
 
 public record SentimentStatsDto(
@@ -19,11 +21,6 @@ public record SentimentStatsDto(
     SentimentShift SentimentShift);
 
 public record StatsPeriod(DateTime From, DateTime To, int Days);
-
-public record SentimentDistribution(
-    double PositivePercent,
-    double NeutralPercent,
-    double NegativePercent);
 
 public record SentimentTrend(
     string Direction,   // "Improving" | "Deteriorating" | "Stable"

--- a/Application/Features/Sentiment/Queries/GetTrendingSymbols/GetTrendingSymbolsQueryHandler.cs
+++ b/Application/Features/Sentiment/Queries/GetTrendingSymbols/GetTrendingSymbolsQueryHandler.cs
@@ -4,12 +4,35 @@ using MediatR;
 
 namespace Application.Features.Sentiment.Queries.GetTrendingSymbols;
 
-public class GetTrendingSymbolsQueryHandler(ISentimentRepository repository)
+public class GetTrendingSymbolsQueryHandler(
+    ISentimentRepository repository,
+    ISymbolSnapshotRepository snapshotRepository)
     : IRequestHandler<GetTrendingSymbolsQuery, IReadOnlyList<TrendingSymbolDto>>
 {
     public async Task<IReadOnlyList<TrendingSymbolDto>> Handle(
         GetTrendingSymbolsQuery query,
         CancellationToken ct)
+    {
+        // Fast path: read precomputed snapshots
+        var snapshots = await snapshotRepository.GetAllAsync(ct);
+
+        if (snapshots.Count > 0)
+        {
+            var dtos = snapshots.Select(s => new TrendingSymbolDto(
+                s.Symbol, s.Score, s.PreviousScore, s.Delta, s.Direction,
+                s.Trend, s.Dispersion, s.ArticleCount));
+
+            return ApplySort(dtos, query.SortBy, query.SortDirection)
+                .Take(query.Limit)
+                .ToList();
+        }
+
+        // Fallback: compute on-the-fly (cold start, no snapshots yet)
+        return await ComputeLive(query, ct);
+    }
+
+    private async Task<IReadOnlyList<TrendingSymbolDto>> ComputeLive(
+        GetTrendingSymbolsQuery query, CancellationToken ct)
     {
         var now = DateTime.UtcNow;
         var windowStart = now.AddHours(-query.Hours);
@@ -25,13 +48,9 @@ public class GetTrendingSymbolsQueryHandler(ISentimentRepository repository)
         var unordered = grouped
             .Select(g => ComputeTrend(g.Key, g.ToList(), midpoint, now));
 
-        var sorted = ApplySort(unordered, query.SortBy, query.SortDirection);
-
-        var results = sorted
+        return ApplySort(unordered, query.SortBy, query.SortDirection)
             .Take(query.Limit)
             .ToList();
-
-        return results;
     }
 
     private static IOrderedEnumerable<TrendingSymbolDto> ApplySort(

--- a/Application/Features/Sentiment/Queries/GetTrendingSymbols/GetTrendingSymbolsQueryHandler.cs
+++ b/Application/Features/Sentiment/Queries/GetTrendingSymbols/GetTrendingSymbolsQueryHandler.cs
@@ -36,7 +36,6 @@ public class GetTrendingSymbolsQueryHandler(
     {
         var now = DateTime.UtcNow;
         var windowStart = now.AddHours(-query.Hours);
-        var midpoint = now.AddHours(-query.Hours / 2.0);
 
         var analyses = await repository.GetRecentAsync(windowStart, ct);
 
@@ -46,7 +45,7 @@ public class GetTrendingSymbolsQueryHandler(
         var grouped = analyses.GroupBy(a => a.Symbol.Value);
 
         var unordered = grouped
-            .Select(g => ComputeTrend(g.Key, g.ToList(), midpoint, now));
+            .Select(g => ComputeTrend(g.Key, g.ToList(), now, query.Hours));
 
         return ApplySort(unordered, query.SortBy, query.SortDirection)
             .Take(query.Limit)
@@ -77,30 +76,11 @@ public class GetTrendingSymbolsQueryHandler(
     private static TrendingSymbolDto ComputeTrend(
         string symbol,
         IReadOnlyList<SentimentAnalysis> analyses,
-        DateTime midpoint,
-        DateTime now)
+        DateTime now,
+        int windowHours = 7 * 24)
     {
-        var current  = analyses.Where(a => a.AnalyzedAt >= midpoint).ToList();
-        var previous = analyses.Where(a => a.AnalyzedAt <  midpoint).ToList();
-
-        var currentAvg  = SentimentMath.DecayWeightedAverage(current, now);
-        var previousAvg = SentimentMath.DecayWeightedAverage(previous, midpoint);
-
-        var delta = Math.Round(currentAvg - previousAvg, 4);
-        currentAvg  = Math.Round(currentAvg,  4);
-        previousAvg = Math.Round(previousAvg, 4);
-
-        var direction = delta switch
-        {
-            > 0  => "up",
-            < 0  => "down",
-            _    => "flat"
-        };
-
-        var trend = SentimentMath.CalculateTrendDirection(analyses);
-        var dispersion = SentimentMath.CalculateDispersion(analyses, now);
-
-        return new TrendingSymbolDto(symbol, currentAvg, previousAvg, delta, direction,
-            trend, dispersion, analyses.Count);
+        var stats = SentimentMath.ComputeSymbolStats(analyses, now, windowHours);
+        return new TrendingSymbolDto(symbol, stats.Score, stats.PreviousScore,
+            stats.Delta, stats.Direction, stats.Trend, stats.Dispersion, stats.ArticleCount);
     }
 }

--- a/Application/Features/Sentiment/Queries/GetTrendingSymbols/GetTrendingSymbolsQueryHandler.cs
+++ b/Application/Features/Sentiment/Queries/GetTrendingSymbols/GetTrendingSymbolsQueryHandler.cs
@@ -48,7 +48,7 @@ public class GetTrendingSymbolsQueryHandler(
 
         var halfLife = scoringOptions.HalfLifeHours;
         var unordered = grouped
-            .Select(g => ComputeTrend(g.Key, g.ToList(), now, query.Hours, halfLife));
+            .Select(g => ToTrendingDto(g.Key, g.ToList(), now, query.Hours, halfLife));
 
         return ApplySort(unordered, query.SortBy, query.SortDirection)
             .Take(query.Limit)
@@ -68,7 +68,7 @@ public class GetTrendingSymbolsQueryHandler(
             "score"      => t => t.CurrentAvgScore,
             "dispersion" => t => t.Dispersion,
             "articles"   => t => t.ArticleCount,
-            _            => t => Math.Abs(t.Delta)
+            _            => t => t.CurrentAvgScore
         };
 
         return descending
@@ -76,7 +76,7 @@ public class GetTrendingSymbolsQueryHandler(
             : items.OrderBy(keySelector);
     }
 
-    private static TrendingSymbolDto ComputeTrend(
+    private static TrendingSymbolDto ToTrendingDto(
         string symbol,
         IReadOnlyList<SentimentAnalysis> analyses,
         DateTime now,

--- a/Application/Features/Sentiment/Queries/GetTrendingSymbols/GetTrendingSymbolsQueryHandler.cs
+++ b/Application/Features/Sentiment/Queries/GetTrendingSymbols/GetTrendingSymbolsQueryHandler.cs
@@ -7,8 +7,6 @@ namespace Application.Features.Sentiment.Queries.GetTrendingSymbols;
 public class GetTrendingSymbolsQueryHandler(ISentimentRepository repository)
     : IRequestHandler<GetTrendingSymbolsQuery, IReadOnlyList<TrendingSymbolDto>>
 {
-    private const int DefaultHalfLifeHours = 72;
-
     public async Task<IReadOnlyList<TrendingSymbolDto>> Handle(
         GetTrendingSymbolsQuery query,
         CancellationToken ct)
@@ -66,8 +64,8 @@ public class GetTrendingSymbolsQueryHandler(ISentimentRepository repository)
         var current  = analyses.Where(a => a.AnalyzedAt >= midpoint).ToList();
         var previous = analyses.Where(a => a.AnalyzedAt <  midpoint).ToList();
 
-        var currentAvg  = DecayWeightedAverage(current, now);
-        var previousAvg = DecayWeightedAverage(previous, midpoint);
+        var currentAvg  = SentimentMath.DecayWeightedAverage(current, now);
+        var previousAvg = SentimentMath.DecayWeightedAverage(previous, midpoint);
 
         var delta = Math.Round(currentAvg - previousAvg, 4);
         currentAvg  = Math.Round(currentAvg,  4);
@@ -80,95 +78,10 @@ public class GetTrendingSymbolsQueryHandler(ISentimentRepository repository)
             _    => "flat"
         };
 
-        // Trend via linear regression over the full window
-        var trend = CalculateTrendDirection(analyses);
-
-        // Dispersion: weighted std dev over all analyses
-        var dispersion = CalculateDispersion(analyses, now);
+        var trend = SentimentMath.CalculateTrendDirection(analyses);
+        var dispersion = SentimentMath.CalculateDispersion(analyses, now);
 
         return new TrendingSymbolDto(symbol, currentAvg, previousAvg, delta, direction,
             trend, dispersion, analyses.Count);
-    }
-
-    private static string CalculateTrendDirection(IReadOnlyList<SentimentAnalysis> analyses)
-    {
-        if (analyses.Count < 2)
-            return "Stable";
-
-        var origin = analyses.Min(a => a.AnalyzedAt);
-        var points = analyses
-            .Select(a => ((a.AnalyzedAt - origin).TotalHours, a.Score.Value))
-            .ToList();
-
-        var n = points.Count;
-        var sumX = points.Sum(p => p.Item1);
-        var sumY = points.Sum(p => p.Item2);
-        var sumXY = points.Sum(p => p.Item1 * p.Item2);
-        var sumX2 = points.Sum(p => p.Item1 * p.Item1);
-
-        var denominator = n * sumX2 - sumX * sumX;
-        if (Math.Abs(denominator) < double.Epsilon)
-            return "Stable";
-
-        var slope = (n * sumXY - sumX * sumY) / denominator;
-
-        return slope switch
-        {
-            > 0.002  => "Improving",
-            < -0.002 => "Deteriorating",
-            _        => "Stable"
-        };
-    }
-
-    private static double CalculateDispersion(IReadOnlyList<SentimentAnalysis> analyses, DateTime now)
-    {
-        if (analyses.Count < 2)
-            return 0.0;
-
-        var totalWeight = 0.0;
-        var weightedSum = 0.0;
-
-        foreach (var a in analyses)
-        {
-            var ageHours = Math.Max(0, (now - a.AnalyzedAt).TotalHours);
-            var weight = Math.Exp(-Math.Log(2) / DefaultHalfLifeHours * ageHours);
-            totalWeight += weight;
-            weightedSum += weight * a.Score.Value;
-        }
-
-        if (totalWeight <= 0) return 0.0;
-        var mean = weightedSum / totalWeight;
-
-        var varianceSum = 0.0;
-        foreach (var a in analyses)
-        {
-            var ageHours = Math.Max(0, (now - a.AnalyzedAt).TotalHours);
-            var weight = Math.Exp(-Math.Log(2) / DefaultHalfLifeHours * ageHours);
-            varianceSum += weight * Math.Pow(a.Score.Value - mean, 2);
-        }
-
-        return Math.Round(Math.Sqrt(varianceSum / totalWeight), 4);
-    }
-
-    private static double DecayWeightedAverage(
-        IReadOnlyList<SentimentAnalysis> analyses,
-        DateTime referenceTime)
-    {
-        if (analyses.Count == 0)
-            return 0.0;
-
-        var totalWeight = 0.0;
-        var weightedSum = 0.0;
-
-        foreach (var a in analyses)
-        {
-            var ageHours = (referenceTime - a.AnalyzedAt).TotalHours;
-            if (ageHours < 0) ageHours = 0;
-            var weight = Math.Exp(-Math.Log(2) / DefaultHalfLifeHours * ageHours);
-            totalWeight += weight;
-            weightedSum += weight * a.Score.Value;
-        }
-
-        return totalWeight > 0 ? weightedSum / totalWeight : 0.0;
     }
 }

--- a/Application/Features/Sentiment/Queries/GetTrendingSymbols/GetTrendingSymbolsQueryHandler.cs
+++ b/Application/Features/Sentiment/Queries/GetTrendingSymbols/GetTrendingSymbolsQueryHandler.cs
@@ -1,3 +1,4 @@
+using Application.Configuration;
 using Domain.Entities;
 using Domain.Interfaces;
 using MediatR;
@@ -6,7 +7,8 @@ namespace Application.Features.Sentiment.Queries.GetTrendingSymbols;
 
 public class GetTrendingSymbolsQueryHandler(
     ISentimentRepository repository,
-    ISymbolSnapshotRepository snapshotRepository)
+    ISymbolSnapshotRepository snapshotRepository,
+    SentimentScoringOptions scoringOptions)
     : IRequestHandler<GetTrendingSymbolsQuery, IReadOnlyList<TrendingSymbolDto>>
 {
     public async Task<IReadOnlyList<TrendingSymbolDto>> Handle(
@@ -44,8 +46,9 @@ public class GetTrendingSymbolsQueryHandler(
 
         var grouped = analyses.GroupBy(a => a.Symbol.Value);
 
+        var halfLife = scoringOptions.HalfLifeHours;
         var unordered = grouped
-            .Select(g => ComputeTrend(g.Key, g.ToList(), now, query.Hours));
+            .Select(g => ComputeTrend(g.Key, g.ToList(), now, query.Hours, halfLife));
 
         return ApplySort(unordered, query.SortBy, query.SortDirection)
             .Take(query.Limit)
@@ -77,9 +80,10 @@ public class GetTrendingSymbolsQueryHandler(
         string symbol,
         IReadOnlyList<SentimentAnalysis> analyses,
         DateTime now,
-        int windowHours = 7 * 24)
+        int windowHours,
+        int halfLifeHours)
     {
-        var stats = SentimentMath.ComputeSymbolStats(analyses, now, windowHours);
+        var stats = SentimentMath.ComputeSymbolStats(analyses, now, windowHours, halfLifeHours);
         return new TrendingSymbolDto(symbol, stats.Score, stats.PreviousScore,
             stats.Delta, stats.Direction, stats.Trend, stats.Dispersion, stats.ArticleCount);
     }

--- a/Application/Features/Sentiment/Queries/GetTrendingSymbols/GetTrendingSymbolsQueryHandler.cs
+++ b/Application/Features/Sentiment/Queries/GetTrendingSymbols/GetTrendingSymbolsQueryHandler.cs
@@ -85,6 +85,6 @@ public class GetTrendingSymbolsQueryHandler(
     {
         var stats = SentimentMath.ComputeSymbolStats(analyses, now, windowHours, halfLifeHours);
         return new TrendingSymbolDto(symbol, stats.Score, stats.PreviousScore,
-            stats.Delta, stats.Direction, stats.Trend, stats.Dispersion, stats.ArticleCount);
+            stats.Delta, stats.Direction, stats.Trend.Direction, stats.Dispersion, stats.ArticleCount);
     }
 }

--- a/Application/Features/Sentiment/SentimentMath.cs
+++ b/Application/Features/Sentiment/SentimentMath.cs
@@ -8,7 +8,7 @@ namespace Application.Features.Sentiment;
 /// </summary>
 public static class SentimentMath
 {
-    public const int DefaultHalfLifeHours = 72;
+    public const int DefaultHalfLifeHours = 72; // fallback if no config injected
 
     public static double DecayWeightedAverage(
         IReadOnlyList<SentimentAnalysis> analyses,
@@ -69,15 +69,16 @@ public static class SentimentMath
     public static SymbolStats ComputeSymbolStats(
         IReadOnlyList<SentimentAnalysis> analyses,
         DateTime now,
-        double windowHours = 7 * 24)
+        double windowHours = 7 * 24,
+        int halfLifeHours = DefaultHalfLifeHours)
     {
         var midpoint = now.AddHours(-windowHours / 2.0);
 
         var current = analyses.Where(a => a.AnalyzedAt >= midpoint).ToList();
         var previous = analyses.Where(a => a.AnalyzedAt < midpoint).ToList();
 
-        var score = Math.Round(DecayWeightedAverage(current, now), 4);
-        var previousScore = Math.Round(DecayWeightedAverage(previous, midpoint), 4);
+        var score = Math.Round(DecayWeightedAverage(current, now, halfLifeHours), 4);
+        var previousScore = Math.Round(DecayWeightedAverage(previous, midpoint, halfLifeHours), 4);
         var delta = Math.Round(score - previousScore, 4);
 
         var direction = delta switch
@@ -88,7 +89,7 @@ public static class SentimentMath
         };
 
         var trend = CalculateTrendDirection(analyses);
-        var dispersion = CalculateDispersion(analyses, now);
+        var dispersion = CalculateDispersion(analyses, now, halfLifeHours);
 
         return new SymbolStats(score, previousScore, delta, direction, trend, dispersion, analyses.Count);
     }

--- a/Application/Features/Sentiment/SentimentMath.cs
+++ b/Application/Features/Sentiment/SentimentMath.cs
@@ -1,0 +1,97 @@
+using Domain.Entities;
+
+namespace Application.Features.Sentiment;
+
+/// <summary>
+/// Shared decay-weighted statistics used by trending, watchlist, and stats handlers.
+/// Half-life = 72 hours: an article's influence halves every 3 days.
+/// </summary>
+public static class SentimentMath
+{
+    public const int DefaultHalfLifeHours = 72;
+
+    public static double DecayWeightedAverage(
+        IReadOnlyList<SentimentAnalysis> analyses,
+        DateTime referenceTime,
+        int halfLifeHours = DefaultHalfLifeHours)
+    {
+        if (analyses.Count == 0)
+            return 0.0;
+
+        var totalWeight = 0.0;
+        var weightedSum = 0.0;
+
+        foreach (var a in analyses)
+        {
+            var ageHours = Math.Max(0, (referenceTime - a.AnalyzedAt).TotalHours);
+            var weight = Math.Exp(-Math.Log(2) / halfLifeHours * ageHours);
+            totalWeight += weight;
+            weightedSum += weight * a.Score.Value;
+        }
+
+        return totalWeight > 0 ? weightedSum / totalWeight : 0.0;
+    }
+
+    public static string CalculateTrendDirection(IReadOnlyList<SentimentAnalysis> analyses)
+    {
+        if (analyses.Count < 2)
+            return "Stable";
+
+        var origin = analyses.Min(a => a.AnalyzedAt);
+        var points = analyses
+            .Select(a => ((a.AnalyzedAt - origin).TotalHours, a.Score.Value))
+            .ToList();
+
+        var n = points.Count;
+        var sumX = points.Sum(p => p.Item1);
+        var sumY = points.Sum(p => p.Item2);
+        var sumXY = points.Sum(p => p.Item1 * p.Item2);
+        var sumX2 = points.Sum(p => p.Item1 * p.Item1);
+
+        var denominator = n * sumX2 - sumX * sumX;
+        if (Math.Abs(denominator) < double.Epsilon)
+            return "Stable";
+
+        var slope = (n * sumXY - sumX * sumY) / denominator;
+
+        return slope switch
+        {
+            > 0.002  => "Improving",
+            < -0.002 => "Deteriorating",
+            _        => "Stable"
+        };
+    }
+
+    public static double CalculateDispersion(
+        IReadOnlyList<SentimentAnalysis> analyses,
+        DateTime now,
+        int halfLifeHours = DefaultHalfLifeHours)
+    {
+        if (analyses.Count < 2)
+            return 0.0;
+
+        var totalWeight = 0.0;
+        var weightedSum = 0.0;
+
+        foreach (var a in analyses)
+        {
+            var ageHours = Math.Max(0, (now - a.AnalyzedAt).TotalHours);
+            var weight = Math.Exp(-Math.Log(2) / halfLifeHours * ageHours);
+            totalWeight += weight;
+            weightedSum += weight * a.Score.Value;
+        }
+
+        if (totalWeight <= 0) return 0.0;
+        var mean = weightedSum / totalWeight;
+
+        var varianceSum = 0.0;
+        foreach (var a in analyses)
+        {
+            var ageHours = Math.Max(0, (now - a.AnalyzedAt).TotalHours);
+            var weight = Math.Exp(-Math.Log(2) / halfLifeHours * ageHours);
+            varianceSum += weight * Math.Pow(a.Score.Value - mean, 2);
+        }
+
+        return Math.Round(Math.Sqrt(varianceSum / totalWeight), 4);
+    }
+}

--- a/Application/Features/Sentiment/SentimentMath.cs
+++ b/Application/Features/Sentiment/SentimentMath.cs
@@ -1,4 +1,5 @@
 using Domain.Entities;
+using Domain.Enums;
 
 namespace Application.Features.Sentiment;
 
@@ -33,34 +34,7 @@ public static class SentimentMath
     }
 
     public static string CalculateTrendDirection(IReadOnlyList<SentimentAnalysis> analyses)
-    {
-        if (analyses.Count < 2)
-            return "Stable";
-
-        var origin = analyses.Min(a => a.AnalyzedAt);
-        var points = analyses
-            .Select(a => ((a.AnalyzedAt - origin).TotalHours, a.Score.Value))
-            .ToList();
-
-        var n = points.Count;
-        var sumX = points.Sum(p => p.Item1);
-        var sumY = points.Sum(p => p.Item2);
-        var sumXY = points.Sum(p => p.Item1 * p.Item2);
-        var sumX2 = points.Sum(p => p.Item1 * p.Item1);
-
-        var denominator = n * sumX2 - sumX * sumX;
-        if (Math.Abs(denominator) < double.Epsilon)
-            return "Stable";
-
-        var slope = (n * sumXY - sumX * sumY) / denominator;
-
-        return slope switch
-        {
-            > 0.002  => "Improving",
-            < -0.002 => "Deteriorating",
-            _        => "Stable"
-        };
-    }
+        => CalculateTrend(analyses).Direction;
 
     /// <summary>
     /// Computes all symbol stats in one call: score, previousScore, delta, direction, trend, dispersion, count.
@@ -126,7 +100,164 @@ public static class SentimentMath
 
         return Math.Round(Math.Sqrt(varianceSum / totalWeight), 4);
     }
+
+    /// <summary>
+    /// Linear regression over (day-offset, score) pairs.
+    /// Returns both direction label and slope value.
+    /// </summary>
+    public static TrendResult CalculateTrend(IReadOnlyList<SentimentAnalysis> analyses)
+    {
+        if (analyses.Count < 2)
+            return new TrendResult("Stable", 0);
+
+        var origin = analyses.Min(a => a.AnalyzedAt);
+        var points = analyses
+            .Select(a => ((a.AnalyzedAt - origin).TotalDays, a.Score.Value))
+            .ToList();
+
+        var n = points.Count;
+        var sumX = points.Sum(p => p.Item1);
+        var sumY = points.Sum(p => p.Item2);
+        var sumXY = points.Sum(p => p.Item1 * p.Item2);
+        var sumX2 = points.Sum(p => p.Item1 * p.Item1);
+
+        var denominator = n * sumX2 - sumX * sumX;
+        if (Math.Abs(denominator) < double.Epsilon)
+            return new TrendResult("Stable", 0);
+
+        var slope = Math.Round((n * sumXY - sumX * sumY) / denominator, 4);
+
+        var direction = slope switch
+        {
+            > 0.005 => "Improving",
+            < -0.005 => "Deteriorating",
+            _ => "Stable"
+        };
+
+        return new TrendResult(direction, slope);
+    }
+
+    /// <summary>
+    /// Computes the total decay weight across all analyses — used for signal strength.
+    /// </summary>
+    public static double TotalDecayWeight(
+        IReadOnlyList<SentimentAnalysis> analyses,
+        DateTime referenceTime,
+        int halfLifeHours = DefaultHalfLifeHours)
+    {
+        var total = 0.0;
+        foreach (var a in analyses)
+        {
+            var ageHours = Math.Max(0, (referenceTime - a.AnalyzedAt).TotalHours);
+            total += Math.Exp(-Math.Log(2) / halfLifeHours * ageHours);
+        }
+        return total;
+    }
+
+    public static string ClassifySignalStrength(double totalWeight) => totalWeight switch
+    {
+        >= 3.0 => "strong",
+        >= 1.0 => "moderate",
+        _ => "no signal"
+    };
+
+    /// <summary>
+    /// Computes sentiment shift by comparing current weighted score to snapshots at 24h and 7d ago.
+    /// </summary>
+    public static (double? Vs24h, double? Vs7d) ComputeSentimentShift(
+        IReadOnlyList<SentimentAnalysis> analyses,
+        DateTime now,
+        int halfLifeHours)
+    {
+        var currentScore = DecayWeightedAverage(analyses, now, halfLifeHours);
+        if (analyses.Count == 0)
+            return (null, null);
+
+        var vs24h = ScoreAsOf(analyses, now.AddHours(-24), halfLifeHours);
+        var vs7d = ScoreAsOf(analyses, now.AddDays(-7), halfLifeHours);
+
+        return (
+            Vs24h: vs24h.HasValue ? Math.Round(currentScore - vs24h.Value, 4) : null,
+            Vs7d: vs7d.HasValue ? Math.Round(currentScore - vs7d.Value, 4) : null);
+    }
+
+    /// <summary>
+    /// Computes decay-weighted average using only articles that existed at the given point in time.
+    /// </summary>
+    public static double? ScoreAsOf(
+        IReadOnlyList<SentimentAnalysis> analyses,
+        DateTime asOf,
+        int halfLifeHours = DefaultHalfLifeHours)
+    {
+        var subset = analyses.Where(a => a.AnalyzedAt <= asOf).ToList();
+        if (subset.Count == 0)
+            return null;
+
+        var totalWeight = 0.0;
+        var weightedSum = 0.0;
+        foreach (var a in subset)
+        {
+            var ageHours = (asOf - a.AnalyzedAt).TotalHours;
+            var weight = Math.Exp(-Math.Log(2) / halfLifeHours * ageHours);
+            totalWeight += weight;
+            weightedSum += weight * a.Score.Value;
+        }
+
+        return totalWeight > 0 ? weightedSum / totalWeight : null;
+    }
+
+    /// <summary>
+    /// Finds the analysis with the highest impact: weight × |score|.
+    /// Returns the analysis and its weight, or null if empty.
+    /// </summary>
+    public static (SentimentAnalysis Analysis, double Weight)? MostImpactful(
+        IReadOnlyList<SentimentAnalysis> analyses,
+        DateTime referenceTime,
+        int halfLifeHours = DefaultHalfLifeHours)
+    {
+        if (analyses.Count == 0) return null;
+
+        SentimentAnalysis? best = null;
+        var bestImpact = -1.0;
+        var bestWeight = 0.0;
+
+        foreach (var a in analyses)
+        {
+            var ageHours = Math.Max(0, (referenceTime - a.AnalyzedAt).TotalHours);
+            var weight = Math.Exp(-Math.Log(2) / halfLifeHours * ageHours);
+            var impact = weight * Math.Abs(a.Score.Value);
+            if (impact > bestImpact)
+            {
+                bestImpact = impact;
+                bestWeight = weight;
+                best = a;
+            }
+        }
+
+        return best is not null ? (best, bestWeight) : null;
+    }
+
+    public static SentimentDistribution ComputeDistribution(IReadOnlyList<SentimentAnalysis> analyses)
+    {
+        var total = analyses.Count;
+        if (total == 0)
+            return new SentimentDistribution(0, 0, 0);
+
+        var positive = analyses.Count(a => a.Label == SentimentLabel.Positive);
+        var neutral = analyses.Count(a => a.Label == SentimentLabel.Neutral);
+        var negative = analyses.Count(a => a.Label == SentimentLabel.Negative);
+
+        return new SentimentDistribution(
+            PositivePercent: Math.Round((double)positive / total * 100, 1),
+            NeutralPercent: Math.Round((double)neutral / total * 100, 1),
+            NegativePercent: Math.Round((double)negative / total * 100, 1));
+    }
 }
+
+public record SentimentDistribution(
+    double PositivePercent,
+    double NeutralPercent,
+    double NegativePercent);
 
 public record SymbolStats(
     double Score,
@@ -136,3 +267,5 @@ public record SymbolStats(
     string Trend,
     double Dispersion,
     int ArticleCount);
+
+public record TrendResult(string Direction, double Slope);

--- a/Application/Features/Sentiment/SentimentMath.cs
+++ b/Application/Features/Sentiment/SentimentMath.cs
@@ -9,7 +9,7 @@ namespace Application.Features.Sentiment;
 /// </summary>
 public static class SentimentMath
 {
-    public const int DefaultHalfLifeHours = 72; // fallback if no config injected
+    public const int DefaultHalfLifeHours = 36; // fallback if no config injected
 
     public static double DecayWeightedAverage(
         IReadOnlyList<SentimentAnalysis> analyses,

--- a/Application/Features/Sentiment/SentimentMath.cs
+++ b/Application/Features/Sentiment/SentimentMath.cs
@@ -62,6 +62,37 @@ public static class SentimentMath
         };
     }
 
+    /// <summary>
+    /// Computes all symbol stats in one call: score, previousScore, delta, direction, trend, dispersion, count.
+    /// Used by ingestion snapshots, trending fallback, and watchlist fallback.
+    /// </summary>
+    public static SymbolStats ComputeSymbolStats(
+        IReadOnlyList<SentimentAnalysis> analyses,
+        DateTime now,
+        double windowHours = 7 * 24)
+    {
+        var midpoint = now.AddHours(-windowHours / 2.0);
+
+        var current = analyses.Where(a => a.AnalyzedAt >= midpoint).ToList();
+        var previous = analyses.Where(a => a.AnalyzedAt < midpoint).ToList();
+
+        var score = Math.Round(DecayWeightedAverage(current, now), 4);
+        var previousScore = Math.Round(DecayWeightedAverage(previous, midpoint), 4);
+        var delta = Math.Round(score - previousScore, 4);
+
+        var direction = delta switch
+        {
+            > 0 => "up",
+            < 0 => "down",
+            _ => "flat"
+        };
+
+        var trend = CalculateTrendDirection(analyses);
+        var dispersion = CalculateDispersion(analyses, now);
+
+        return new SymbolStats(score, previousScore, delta, direction, trend, dispersion, analyses.Count);
+    }
+
     public static double CalculateDispersion(
         IReadOnlyList<SentimentAnalysis> analyses,
         DateTime now,
@@ -95,3 +126,12 @@ public static class SentimentMath
         return Math.Round(Math.Sqrt(varianceSum / totalWeight), 4);
     }
 }
+
+public record SymbolStats(
+    double Score,
+    double PreviousScore,
+    double Delta,
+    string Direction,
+    string Trend,
+    double Dispersion,
+    int ArticleCount);

--- a/Application/Features/Sentiment/SentimentMath.cs
+++ b/Application/Features/Sentiment/SentimentMath.cs
@@ -43,7 +43,7 @@ public static class SentimentMath
     public static SymbolStats ComputeSymbolStats(
         IReadOnlyList<SentimentAnalysis> analyses,
         DateTime now,
-        double windowHours = 7 * 24,
+        double windowHours = 14 * 24,
         int halfLifeHours = DefaultHalfLifeHours)
     {
         var midpoint = now.AddHours(-windowHours / 2.0);
@@ -62,10 +62,19 @@ public static class SentimentMath
             _ => "flat"
         };
 
-        var trend = CalculateTrendDirection(analyses);
+        var trend = CalculateTrend(analyses);
         var dispersion = CalculateDispersion(analyses, now, halfLifeHours);
+        var totalWeight = TotalDecayWeight(analyses, now, halfLifeHours);
+        var signalStrength = ClassifySignalStrength(totalWeight);
+        var distribution = ComputeDistribution(analyses);
+        var shift = ComputeSentimentShift(analyses, now, halfLifeHours);
+        var impactful = MostImpactful(analyses, now, halfLifeHours);
 
-        return new SymbolStats(score, previousScore, delta, direction, trend, dispersion, analyses.Count);
+        return new SymbolStats(
+            score, previousScore, delta, direction,
+            trend, dispersion, analyses.Count,
+            totalWeight, signalStrength, distribution,
+            shift, impactful);
     }
 
     public static double CalculateDispersion(
@@ -264,8 +273,13 @@ public record SymbolStats(
     double PreviousScore,
     double Delta,
     string Direction,
-    string Trend,
+    TrendResult Trend,
     double Dispersion,
-    int ArticleCount);
+    int ArticleCount,
+    double TotalWeight,
+    string SignalStrength,
+    SentimentDistribution Distribution,
+    (double? Vs24h, double? Vs7d) Shift,
+    (SentimentAnalysis Analysis, double Weight)? MostImpactful);
 
 public record TrendResult(string Direction, double Slope);

--- a/Application/Features/Watchlist/Commands/AddToWatchlist/AddToWatchlistCommand.cs
+++ b/Application/Features/Watchlist/Commands/AddToWatchlist/AddToWatchlistCommand.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace Application.Features.Watchlist.Commands.AddToWatchlist;
+
+public record AddToWatchlistCommand(string Symbol) : IRequest<WatchlistSymbolDto>;

--- a/Application/Features/Watchlist/Commands/AddToWatchlist/AddToWatchlistCommandHandler.cs
+++ b/Application/Features/Watchlist/Commands/AddToWatchlist/AddToWatchlistCommandHandler.cs
@@ -1,0 +1,43 @@
+using Application.Services;
+using Domain.Entities;
+using Domain.Interfaces;
+using FluentValidation.Results;
+using MediatR;
+
+namespace Application.Features.Watchlist.Commands.AddToWatchlist;
+
+public class AddToWatchlistCommandHandler(
+    ITrackedSymbolRepository repository,
+    ISymbolValidationService validationService)
+    : IRequestHandler<AddToWatchlistCommand, WatchlistSymbolDto>
+{
+    public async Task<WatchlistSymbolDto> Handle(
+        AddToWatchlistCommand request, CancellationToken cancellationToken)
+    {
+        var upper = request.Symbol.ToUpperInvariant();
+
+        var existing = await repository.GetBySymbolAsync(upper, cancellationToken);
+
+        if (existing is not null)
+        {
+            if (existing.Source == "watchlist")
+                return new WatchlistSymbolDto(existing.Symbol, existing.AddedAt, 0, "Stable", 0, 0);
+
+            // Symbol exists as "seed" — promote to "watchlist"
+            existing.UpdateSource("watchlist");
+            await repository.UpdateAsync(existing, cancellationToken);
+            return new WatchlistSymbolDto(existing.Symbol, existing.AddedAt, 0, "Stable", 0, 0);
+        }
+
+        // New symbol — validate with Yahoo Finance
+        var isValid = await validationService.IsValidSymbolAsync(upper, cancellationToken);
+        if (!isValid)
+            throw new Application.Exceptions.ValidationException(
+                [new ValidationFailure("Symbol", $"Symbol '{upper}' is not a valid stock or crypto symbol.")]);
+
+        var entity = TrackedSymbol.Create(upper, "watchlist");
+        await repository.AddAsync(entity, cancellationToken);
+
+        return new WatchlistSymbolDto(entity.Symbol, entity.AddedAt, 0, "Stable", 0, 0);
+    }
+}

--- a/Application/Features/Watchlist/Commands/AddToWatchlist/AddToWatchlistCommandValidator.cs
+++ b/Application/Features/Watchlist/Commands/AddToWatchlist/AddToWatchlistCommandValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+
+namespace Application.Features.Watchlist.Commands.AddToWatchlist;
+
+public class AddToWatchlistCommandValidator : AbstractValidator<AddToWatchlistCommand>
+{
+    public AddToWatchlistCommandValidator()
+    {
+        RuleFor(x => x.Symbol)
+            .NotEmpty().WithMessage("Symbol is required.")
+            .MaximumLength(10).WithMessage("Symbol cannot exceed 10 characters.")
+            .Matches(@"^[A-Za-z0-9\-\.]+$").WithMessage("Symbol may only contain letters, digits, hyphens, and dots.");
+    }
+}

--- a/Application/Features/Watchlist/Commands/RemoveFromWatchlist/RemoveFromWatchlistCommand.cs
+++ b/Application/Features/Watchlist/Commands/RemoveFromWatchlist/RemoveFromWatchlistCommand.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace Application.Features.Watchlist.Commands.RemoveFromWatchlist;
+
+public record RemoveFromWatchlistCommand(string Symbol) : IRequest;

--- a/Application/Features/Watchlist/Commands/RemoveFromWatchlist/RemoveFromWatchlistCommandHandler.cs
+++ b/Application/Features/Watchlist/Commands/RemoveFromWatchlist/RemoveFromWatchlistCommandHandler.cs
@@ -1,0 +1,21 @@
+using Application.Exceptions;
+using Domain.Interfaces;
+using MediatR;
+
+namespace Application.Features.Watchlist.Commands.RemoveFromWatchlist;
+
+public class RemoveFromWatchlistCommandHandler(ITrackedSymbolRepository repository)
+    : IRequestHandler<RemoveFromWatchlistCommand>
+{
+    public async Task Handle(
+        RemoveFromWatchlistCommand request, CancellationToken cancellationToken)
+    {
+        var upper = request.Symbol.ToUpperInvariant();
+        var existing = await repository.GetBySymbolAsync(upper, cancellationToken);
+
+        if (existing is null || existing.Source != "watchlist")
+            throw new NotFoundException("Watchlist symbol", upper);
+
+        await repository.RemoveAsync(upper, cancellationToken);
+    }
+}

--- a/Application/Features/Watchlist/Queries/GetWatchlist/GetWatchlistQuery.cs
+++ b/Application/Features/Watchlist/Queries/GetWatchlist/GetWatchlistQuery.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace Application.Features.Watchlist.Queries.GetWatchlist;
+
+public record GetWatchlistQuery : IRequest<IReadOnlyList<WatchlistSymbolDto>>;

--- a/Application/Features/Watchlist/Queries/GetWatchlist/GetWatchlistQueryHandler.cs
+++ b/Application/Features/Watchlist/Queries/GetWatchlist/GetWatchlistQueryHandler.cs
@@ -47,7 +47,7 @@ public class GetWatchlistQueryHandler(
 
             results.Add(new WatchlistSymbolDto(
                 tracked.Symbol, tracked.AddedAt,
-                stats.Score, stats.Trend, stats.Dispersion, stats.ArticleCount));
+                stats.Score, stats.Trend.Direction, stats.Dispersion, stats.ArticleCount));
         }
 
         return results;

--- a/Application/Features/Watchlist/Queries/GetWatchlist/GetWatchlistQueryHandler.cs
+++ b/Application/Features/Watchlist/Queries/GetWatchlist/GetWatchlistQueryHandler.cs
@@ -41,13 +41,11 @@ public class GetWatchlistQueryHandler(
             var analyses = await sentimentRepository.GetForStatsAsync(
                 new StockSymbol(tracked.Symbol), DataWindowDays, ct);
 
-            var score = SentimentMath.DecayWeightedAverage(analyses, now);
-            var trend = SentimentMath.CalculateTrendDirection(analyses);
-            var dispersion = SentimentMath.CalculateDispersion(analyses, now);
+            var stats = SentimentMath.ComputeSymbolStats(analyses, now, DataWindowDays * 24);
 
             results.Add(new WatchlistSymbolDto(
                 tracked.Symbol, tracked.AddedAt,
-                Math.Round(score, 4), trend, dispersion, analyses.Count));
+                stats.Score, stats.Trend, stats.Dispersion, stats.ArticleCount));
         }
 
         return results;

--- a/Application/Features/Watchlist/Queries/GetWatchlist/GetWatchlistQueryHandler.cs
+++ b/Application/Features/Watchlist/Queries/GetWatchlist/GetWatchlistQueryHandler.cs
@@ -1,4 +1,4 @@
-using Domain.Entities;
+using Application.Features.Sentiment;
 using Domain.Interfaces;
 using Domain.ValueObjects;
 using MediatR;
@@ -10,7 +10,6 @@ public class GetWatchlistQueryHandler(
     ISentimentRepository sentimentRepository)
     : IRequestHandler<GetWatchlistQuery, IReadOnlyList<WatchlistSymbolDto>>
 {
-    private const int DefaultHalfLifeHours = 72;
     private const int DataWindowDays = 7;
 
     public async Task<IReadOnlyList<WatchlistSymbolDto>> Handle(
@@ -29,9 +28,9 @@ public class GetWatchlistQueryHandler(
             var analyses = await sentimentRepository.GetForStatsAsync(
                 new StockSymbol(tracked.Symbol), DataWindowDays, ct);
 
-            var score = DecayWeightedAverage(analyses, now);
-            var trend = CalculateTrendDirection(analyses);
-            var dispersion = CalculateDispersion(analyses, now);
+            var score = SentimentMath.DecayWeightedAverage(analyses, now);
+            var trend = SentimentMath.CalculateTrendDirection(analyses);
+            var dispersion = SentimentMath.CalculateDispersion(analyses, now);
 
             results.Add(new WatchlistSymbolDto(
                 tracked.Symbol,
@@ -43,82 +42,5 @@ public class GetWatchlistQueryHandler(
         }
 
         return results;
-    }
-
-    private static double DecayWeightedAverage(
-        IReadOnlyList<SentimentAnalysis> analyses, DateTime now)
-    {
-        if (analyses.Count == 0) return 0.0;
-
-        var totalWeight = 0.0;
-        var weightedSum = 0.0;
-
-        foreach (var a in analyses)
-        {
-            var ageHours = Math.Max(0, (now - a.AnalyzedAt).TotalHours);
-            var weight = Math.Exp(-Math.Log(2) / DefaultHalfLifeHours * ageHours);
-            totalWeight += weight;
-            weightedSum += weight * a.Score.Value;
-        }
-
-        return totalWeight > 0 ? weightedSum / totalWeight : 0.0;
-    }
-
-    private static string CalculateTrendDirection(IReadOnlyList<SentimentAnalysis> analyses)
-    {
-        if (analyses.Count < 2) return "Stable";
-
-        var origin = analyses.Min(a => a.AnalyzedAt);
-        var points = analyses
-            .Select(a => ((a.AnalyzedAt - origin).TotalHours, a.Score.Value))
-            .ToList();
-
-        var n = points.Count;
-        var sumX = points.Sum(p => p.Item1);
-        var sumY = points.Sum(p => p.Item2);
-        var sumXY = points.Sum(p => p.Item1 * p.Item2);
-        var sumX2 = points.Sum(p => p.Item1 * p.Item1);
-
-        var denominator = n * sumX2 - sumX * sumX;
-        if (Math.Abs(denominator) < double.Epsilon) return "Stable";
-
-        var slope = (n * sumXY - sumX * sumY) / denominator;
-
-        return slope switch
-        {
-            > 0.002  => "Improving",
-            < -0.002 => "Deteriorating",
-            _        => "Stable"
-        };
-    }
-
-    private static double CalculateDispersion(
-        IReadOnlyList<SentimentAnalysis> analyses, DateTime now)
-    {
-        if (analyses.Count < 2) return 0.0;
-
-        var totalWeight = 0.0;
-        var weightedSum = 0.0;
-
-        foreach (var a in analyses)
-        {
-            var ageHours = Math.Max(0, (now - a.AnalyzedAt).TotalHours);
-            var weight = Math.Exp(-Math.Log(2) / DefaultHalfLifeHours * ageHours);
-            totalWeight += weight;
-            weightedSum += weight * a.Score.Value;
-        }
-
-        if (totalWeight <= 0) return 0.0;
-        var mean = weightedSum / totalWeight;
-
-        var varianceSum = 0.0;
-        foreach (var a in analyses)
-        {
-            var ageHours = Math.Max(0, (now - a.AnalyzedAt).TotalHours);
-            var weight = Math.Exp(-Math.Log(2) / DefaultHalfLifeHours * ageHours);
-            varianceSum += weight * Math.Pow(a.Score.Value - mean, 2);
-        }
-
-        return Math.Round(Math.Sqrt(varianceSum / totalWeight), 4);
     }
 }

--- a/Application/Features/Watchlist/Queries/GetWatchlist/GetWatchlistQueryHandler.cs
+++ b/Application/Features/Watchlist/Queries/GetWatchlist/GetWatchlistQueryHandler.cs
@@ -1,3 +1,4 @@
+using Application.Configuration;
 using Application.Features.Sentiment;
 using Domain.Interfaces;
 using Domain.ValueObjects;
@@ -8,10 +9,10 @@ namespace Application.Features.Watchlist.Queries.GetWatchlist;
 public class GetWatchlistQueryHandler(
     ITrackedSymbolRepository trackedSymbolRepository,
     ISentimentRepository sentimentRepository,
-    ISymbolSnapshotRepository snapshotRepository)
+    ISymbolSnapshotRepository snapshotRepository,
+    SentimentScoringOptions scoringOptions)
     : IRequestHandler<GetWatchlistQuery, IReadOnlyList<WatchlistSymbolDto>>
 {
-    private const int DataWindowDays = 7;
 
     public async Task<IReadOnlyList<WatchlistSymbolDto>> Handle(
         GetWatchlistQuery request, CancellationToken ct)
@@ -39,9 +40,10 @@ public class GetWatchlistQueryHandler(
 
             // Fallback: compute on-the-fly (new symbol, no snapshot yet)
             var analyses = await sentimentRepository.GetForStatsAsync(
-                new StockSymbol(tracked.Symbol), DataWindowDays, ct);
+                new StockSymbol(tracked.Symbol), scoringOptions.DefaultWindowDays, ct);
 
-            var stats = SentimentMath.ComputeSymbolStats(analyses, now, DataWindowDays * 24);
+            var stats = SentimentMath.ComputeSymbolStats(
+                analyses, now, scoringOptions.DefaultWindowDays * 24, scoringOptions.HalfLifeHours);
 
             results.Add(new WatchlistSymbolDto(
                 tracked.Symbol, tracked.AddedAt,

--- a/Application/Features/Watchlist/Queries/GetWatchlist/GetWatchlistQueryHandler.cs
+++ b/Application/Features/Watchlist/Queries/GetWatchlist/GetWatchlistQueryHandler.cs
@@ -7,7 +7,8 @@ namespace Application.Features.Watchlist.Queries.GetWatchlist;
 
 public class GetWatchlistQueryHandler(
     ITrackedSymbolRepository trackedSymbolRepository,
-    ISentimentRepository sentimentRepository)
+    ISentimentRepository sentimentRepository,
+    ISymbolSnapshotRepository snapshotRepository)
     : IRequestHandler<GetWatchlistQuery, IReadOnlyList<WatchlistSymbolDto>>
 {
     private const int DataWindowDays = 7;
@@ -25,6 +26,18 @@ public class GetWatchlistQueryHandler(
 
         foreach (var tracked in watchlistSymbols)
         {
+            // Fast path: read precomputed snapshot
+            var snapshot = await snapshotRepository.GetBySymbolAsync(tracked.Symbol, ct);
+
+            if (snapshot is not null)
+            {
+                results.Add(new WatchlistSymbolDto(
+                    tracked.Symbol, tracked.AddedAt,
+                    snapshot.Score, snapshot.Trend, snapshot.Dispersion, snapshot.ArticleCount));
+                continue;
+            }
+
+            // Fallback: compute on-the-fly (new symbol, no snapshot yet)
             var analyses = await sentimentRepository.GetForStatsAsync(
                 new StockSymbol(tracked.Symbol), DataWindowDays, ct);
 
@@ -33,12 +46,8 @@ public class GetWatchlistQueryHandler(
             var dispersion = SentimentMath.CalculateDispersion(analyses, now);
 
             results.Add(new WatchlistSymbolDto(
-                tracked.Symbol,
-                tracked.AddedAt,
-                Math.Round(score, 4),
-                trend,
-                dispersion,
-                analyses.Count));
+                tracked.Symbol, tracked.AddedAt,
+                Math.Round(score, 4), trend, dispersion, analyses.Count));
         }
 
         return results;

--- a/Application/Features/Watchlist/Queries/GetWatchlist/GetWatchlistQueryHandler.cs
+++ b/Application/Features/Watchlist/Queries/GetWatchlist/GetWatchlistQueryHandler.cs
@@ -43,7 +43,7 @@ public class GetWatchlistQueryHandler(
                 new StockSymbol(tracked.Symbol), scoringOptions.DefaultWindowDays, ct);
 
             var stats = SentimentMath.ComputeSymbolStats(
-                analyses, now, scoringOptions.DefaultWindowDays * 24, scoringOptions.HalfLifeHours);
+                analyses, now, scoringOptions.DefaultWindowDays * 24.0, scoringOptions.HalfLifeHours);
 
             results.Add(new WatchlistSymbolDto(
                 tracked.Symbol, tracked.AddedAt,

--- a/Application/Features/Watchlist/Queries/GetWatchlist/GetWatchlistQueryHandler.cs
+++ b/Application/Features/Watchlist/Queries/GetWatchlist/GetWatchlistQueryHandler.cs
@@ -1,0 +1,124 @@
+using Domain.Entities;
+using Domain.Interfaces;
+using Domain.ValueObjects;
+using MediatR;
+
+namespace Application.Features.Watchlist.Queries.GetWatchlist;
+
+public class GetWatchlistQueryHandler(
+    ITrackedSymbolRepository trackedSymbolRepository,
+    ISentimentRepository sentimentRepository)
+    : IRequestHandler<GetWatchlistQuery, IReadOnlyList<WatchlistSymbolDto>>
+{
+    private const int DefaultHalfLifeHours = 72;
+    private const int DataWindowDays = 7;
+
+    public async Task<IReadOnlyList<WatchlistSymbolDto>> Handle(
+        GetWatchlistQuery request, CancellationToken ct)
+    {
+        var watchlistSymbols = await trackedSymbolRepository.GetBySourceAsync("watchlist", ct);
+
+        if (watchlistSymbols.Count == 0)
+            return [];
+
+        var now = DateTime.UtcNow;
+        var results = new List<WatchlistSymbolDto>();
+
+        foreach (var tracked in watchlistSymbols)
+        {
+            var analyses = await sentimentRepository.GetForStatsAsync(
+                new StockSymbol(tracked.Symbol), DataWindowDays, ct);
+
+            var score = DecayWeightedAverage(analyses, now);
+            var trend = CalculateTrendDirection(analyses);
+            var dispersion = CalculateDispersion(analyses, now);
+
+            results.Add(new WatchlistSymbolDto(
+                tracked.Symbol,
+                tracked.AddedAt,
+                Math.Round(score, 4),
+                trend,
+                dispersion,
+                analyses.Count));
+        }
+
+        return results;
+    }
+
+    private static double DecayWeightedAverage(
+        IReadOnlyList<SentimentAnalysis> analyses, DateTime now)
+    {
+        if (analyses.Count == 0) return 0.0;
+
+        var totalWeight = 0.0;
+        var weightedSum = 0.0;
+
+        foreach (var a in analyses)
+        {
+            var ageHours = Math.Max(0, (now - a.AnalyzedAt).TotalHours);
+            var weight = Math.Exp(-Math.Log(2) / DefaultHalfLifeHours * ageHours);
+            totalWeight += weight;
+            weightedSum += weight * a.Score.Value;
+        }
+
+        return totalWeight > 0 ? weightedSum / totalWeight : 0.0;
+    }
+
+    private static string CalculateTrendDirection(IReadOnlyList<SentimentAnalysis> analyses)
+    {
+        if (analyses.Count < 2) return "Stable";
+
+        var origin = analyses.Min(a => a.AnalyzedAt);
+        var points = analyses
+            .Select(a => ((a.AnalyzedAt - origin).TotalHours, a.Score.Value))
+            .ToList();
+
+        var n = points.Count;
+        var sumX = points.Sum(p => p.Item1);
+        var sumY = points.Sum(p => p.Item2);
+        var sumXY = points.Sum(p => p.Item1 * p.Item2);
+        var sumX2 = points.Sum(p => p.Item1 * p.Item1);
+
+        var denominator = n * sumX2 - sumX * sumX;
+        if (Math.Abs(denominator) < double.Epsilon) return "Stable";
+
+        var slope = (n * sumXY - sumX * sumY) / denominator;
+
+        return slope switch
+        {
+            > 0.002  => "Improving",
+            < -0.002 => "Deteriorating",
+            _        => "Stable"
+        };
+    }
+
+    private static double CalculateDispersion(
+        IReadOnlyList<SentimentAnalysis> analyses, DateTime now)
+    {
+        if (analyses.Count < 2) return 0.0;
+
+        var totalWeight = 0.0;
+        var weightedSum = 0.0;
+
+        foreach (var a in analyses)
+        {
+            var ageHours = Math.Max(0, (now - a.AnalyzedAt).TotalHours);
+            var weight = Math.Exp(-Math.Log(2) / DefaultHalfLifeHours * ageHours);
+            totalWeight += weight;
+            weightedSum += weight * a.Score.Value;
+        }
+
+        if (totalWeight <= 0) return 0.0;
+        var mean = weightedSum / totalWeight;
+
+        var varianceSum = 0.0;
+        foreach (var a in analyses)
+        {
+            var ageHours = Math.Max(0, (now - a.AnalyzedAt).TotalHours);
+            var weight = Math.Exp(-Math.Log(2) / DefaultHalfLifeHours * ageHours);
+            varianceSum += weight * Math.Pow(a.Score.Value - mean, 2);
+        }
+
+        return Math.Round(Math.Sqrt(varianceSum / totalWeight), 4);
+    }
+}

--- a/Application/Features/Watchlist/WatchlistSymbolDto.cs
+++ b/Application/Features/Watchlist/WatchlistSymbolDto.cs
@@ -1,0 +1,9 @@
+namespace Application.Features.Watchlist;
+
+public record WatchlistSymbolDto(
+    string Symbol,
+    DateTime AddedAt,
+    double Score,
+    string Trend,
+    double Dispersion,
+    int ArticleCount);

--- a/Application/Services/ISymbolValidationService.cs
+++ b/Application/Services/ISymbolValidationService.cs
@@ -1,0 +1,6 @@
+namespace Application.Services;
+
+public interface ISymbolValidationService
+{
+    Task<bool> IsValidSymbolAsync(string symbol, CancellationToken ct = default);
+}

--- a/Domain/Entities/SymbolSnapshot.cs
+++ b/Domain/Entities/SymbolSnapshot.cs
@@ -1,0 +1,65 @@
+namespace Domain.Entities;
+
+/// <summary>
+/// Precomputed sentiment statistics for a symbol, materialized after each analysis.
+/// Read by trending and watchlist endpoints for instant responses.
+/// </summary>
+public class SymbolSnapshot
+{
+    public Guid Id { get; private set; }
+    public string Symbol { get; private set; } = null!;
+    public double Score { get; private set; }
+    public double PreviousScore { get; private set; }
+    public double Delta { get; private set; }
+    public string Direction { get; private set; } = "flat";
+    public string Trend { get; private set; } = "Stable";
+    public double Dispersion { get; private set; }
+    public int ArticleCount { get; private set; }
+    public DateTime UpdatedAt { get; private set; }
+
+    private SymbolSnapshot() { }
+
+    public static SymbolSnapshot Create(
+        string symbol,
+        double score,
+        double previousScore,
+        double delta,
+        string direction,
+        string trend,
+        double dispersion,
+        int articleCount)
+    {
+        return new SymbolSnapshot
+        {
+            Id = Guid.NewGuid(),
+            Symbol = symbol,
+            Score = score,
+            PreviousScore = previousScore,
+            Delta = delta,
+            Direction = direction,
+            Trend = trend,
+            Dispersion = dispersion,
+            ArticleCount = articleCount,
+            UpdatedAt = DateTime.UtcNow
+        };
+    }
+
+    public void Update(
+        double score,
+        double previousScore,
+        double delta,
+        string direction,
+        string trend,
+        double dispersion,
+        int articleCount)
+    {
+        Score = score;
+        PreviousScore = previousScore;
+        Delta = delta;
+        Direction = direction;
+        Trend = trend;
+        Dispersion = dispersion;
+        ArticleCount = articleCount;
+        UpdatedAt = DateTime.UtcNow;
+    }
+}

--- a/Domain/Entities/TrackedSymbol.cs
+++ b/Domain/Entities/TrackedSymbol.cs
@@ -11,6 +11,7 @@ public class TrackedSymbol
 {
     public Guid Id { get; private set; }
     public string Symbol { get; private set; } = null!;
+    public string Source { get; private set; } = "seed";
     public DateTime AddedAt { get; private set; }
 
     /// <summary>
@@ -18,7 +19,7 @@ public class TrackedSymbol
     /// </summary>
     private TrackedSymbol() { }
 
-    public static TrackedSymbol Create(string symbol)
+    public static TrackedSymbol Create(string symbol, string source = "seed")
     {
         if (string.IsNullOrWhiteSpace(symbol))
             throw new DomainException("Symbol cannot be empty.");
@@ -26,11 +27,23 @@ public class TrackedSymbol
         if (symbol.Length > 10)
             throw new DomainException("Symbol cannot exceed 10 characters.");
 
+        if (source is not ("seed" or "watchlist"))
+            throw new DomainException("Source must be 'seed' or 'watchlist'.");
+
         return new TrackedSymbol
         {
             Id       = Guid.NewGuid(),
             Symbol   = symbol.ToUpperInvariant(),
+            Source   = source,
             AddedAt  = DateTime.UtcNow
         };
+    }
+
+    public void UpdateSource(string source)
+    {
+        if (source is not ("seed" or "watchlist"))
+            throw new DomainException("Source must be 'seed' or 'watchlist'.");
+
+        Source = source;
     }
 }

--- a/Domain/Interfaces/ISymbolSnapshotRepository.cs
+++ b/Domain/Interfaces/ISymbolSnapshotRepository.cs
@@ -1,0 +1,10 @@
+using Domain.Entities;
+
+namespace Domain.Interfaces;
+
+public interface ISymbolSnapshotRepository
+{
+    Task<SymbolSnapshot?> GetBySymbolAsync(string symbol, CancellationToken ct = default);
+    Task<IReadOnlyList<SymbolSnapshot>> GetAllAsync(CancellationToken ct = default);
+    Task UpsertAsync(SymbolSnapshot snapshot, CancellationToken ct = default);
+}

--- a/Domain/Interfaces/ITrackedSymbolRepository.cs
+++ b/Domain/Interfaces/ITrackedSymbolRepository.cs
@@ -9,8 +9,11 @@ namespace Domain.Interfaces;
 public interface ITrackedSymbolRepository
 {
     Task<IReadOnlyList<TrackedSymbol>> GetAllAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<TrackedSymbol>> GetBySourceAsync(string source, CancellationToken ct = default);
+    Task<TrackedSymbol?> GetBySymbolAsync(string symbol, CancellationToken ct = default);
     Task<bool> ExistsAsync(string symbol, CancellationToken ct = default);
     Task AddAsync(TrackedSymbol symbol, CancellationToken ct = default);
+    Task UpdateAsync(TrackedSymbol symbol, CancellationToken ct = default);
 
     /// <summary>
     /// Removes a tracked symbol, if it exists.

--- a/Infrastructure/DependencyInjection.cs
+++ b/Infrastructure/DependencyInjection.cs
@@ -1,3 +1,4 @@
+using Application.Configuration;
 using Application.Services;
 using Domain.Interfaces;
 using Infrastructure.Ingestion;
@@ -27,6 +28,12 @@ public static class DependencyInjection
         services.AddScoped<ITrackedSymbolsProvider, DbTrackedSymbolsProvider>();
         services.AddScoped<ISymbolSnapshotRepository, SymbolSnapshotRepository>();
         services.AddScoped<ISystemStatsRepository, SystemStatsRepository>();
+
+        // --- Scoring Configuration ---
+        var scoringOptions = configuration
+            .GetSection(SentimentScoringOptions.SectionName)
+            .Get<SentimentScoringOptions>() ?? new SentimentScoringOptions();
+        services.AddSingleton(scoringOptions);
 
         // --- AI Service (switchable via config) ---
         var aiProvider = configuration["AI:Provider"] ?? "Mock";

--- a/Infrastructure/DependencyInjection.cs
+++ b/Infrastructure/DependencyInjection.cs
@@ -25,6 +25,7 @@ public static class DependencyInjection
         services.AddScoped<ISentimentRepository, SentimentRepository>();
         services.AddScoped<ITrackedSymbolRepository, TrackedSymbolRepository>();
         services.AddScoped<ITrackedSymbolsProvider, DbTrackedSymbolsProvider>();
+        services.AddScoped<ISymbolSnapshotRepository, SymbolSnapshotRepository>();
         services.AddScoped<ISystemStatsRepository, SystemStatsRepository>();
 
         // --- AI Service (switchable via config) ---

--- a/Infrastructure/DependencyInjection.cs
+++ b/Infrastructure/DependencyInjection.cs
@@ -77,6 +77,13 @@ public static class DependencyInjection
                 break;
         }
 
+        // --- Symbol Validation ---
+        services.AddHttpClient<ISymbolValidationService, YahooSymbolValidationService>(client =>
+        {
+            client.DefaultRequestHeaders.UserAgent.ParseAdd(
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36");
+        });
+
         // --- Ingestion Pipeline ---
         services.Configure<IngestionOptions>(
             configuration.GetSection(IngestionOptions.SectionName));

--- a/Infrastructure/Migrations/20260320050344_AddSourceToTrackedSymbol.Designer.cs
+++ b/Infrastructure/Migrations/20260320050344_AddSourceToTrackedSymbol.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260320050344_AddSourceToTrackedSymbol")]
+    partial class AddSourceToTrackedSymbol
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Infrastructure/Migrations/20260320050344_AddSourceToTrackedSymbol.cs
+++ b/Infrastructure/Migrations/20260320050344_AddSourceToTrackedSymbol.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSourceToTrackedSymbol : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Source",
+                table: "TrackedSymbols",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: false,
+                defaultValue: "seed");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Source",
+                table: "TrackedSymbols");
+        }
+    }
+}

--- a/Infrastructure/Migrations/20260320061517_AddSymbolSnapshotEntity.Designer.cs
+++ b/Infrastructure/Migrations/20260320061517_AddSymbolSnapshotEntity.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260320061517_AddSymbolSnapshotEntity")]
+    partial class AddSymbolSnapshotEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Infrastructure/Migrations/20260320061517_AddSymbolSnapshotEntity.cs
+++ b/Infrastructure/Migrations/20260320061517_AddSymbolSnapshotEntity.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSymbolSnapshotEntity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "SymbolSnapshots",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Symbol = table.Column<string>(type: "character varying(10)", maxLength: 10, nullable: false),
+                    Score = table.Column<double>(type: "double precision", nullable: false),
+                    PreviousScore = table.Column<double>(type: "double precision", nullable: false),
+                    Delta = table.Column<double>(type: "double precision", nullable: false),
+                    Direction = table.Column<string>(type: "character varying(10)", maxLength: 10, nullable: false),
+                    Trend = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    Dispersion = table.Column<double>(type: "double precision", nullable: false),
+                    ArticleCount = table.Column<int>(type: "integer", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SymbolSnapshots", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SymbolSnapshots_Symbol",
+                table: "SymbolSnapshots",
+                column: "Symbol",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SymbolSnapshots");
+        }
+    }
+}

--- a/Infrastructure/Persistence/AppDbContext.cs
+++ b/Infrastructure/Persistence/AppDbContext.cs
@@ -13,6 +13,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
 {
     public DbSet<SentimentAnalysis> SentimentAnalyses => Set<SentimentAnalysis>();
     public DbSet<TrackedSymbol> TrackedSymbols => Set<TrackedSymbol>();
+    public DbSet<SymbolSnapshot> SymbolSnapshots => Set<SymbolSnapshot>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/Infrastructure/Persistence/Configurations/SymbolSnapshotConfiguration.cs
+++ b/Infrastructure/Persistence/Configurations/SymbolSnapshotConfiguration.cs
@@ -1,0 +1,39 @@
+using Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Infrastructure.Persistence.Configurations;
+
+public class SymbolSnapshotConfiguration : IEntityTypeConfiguration<SymbolSnapshot>
+{
+    public void Configure(EntityTypeBuilder<SymbolSnapshot> builder)
+    {
+        builder.ToTable("SymbolSnapshots");
+
+        builder.HasKey(s => s.Id);
+
+        builder.Property(s => s.Symbol)
+            .HasMaxLength(10)
+            .IsRequired();
+
+        builder.Property(s => s.Score).IsRequired();
+        builder.Property(s => s.PreviousScore).IsRequired();
+        builder.Property(s => s.Delta).IsRequired();
+
+        builder.Property(s => s.Direction)
+            .HasMaxLength(10)
+            .IsRequired();
+
+        builder.Property(s => s.Trend)
+            .HasMaxLength(20)
+            .IsRequired();
+
+        builder.Property(s => s.Dispersion).IsRequired();
+        builder.Property(s => s.ArticleCount).IsRequired();
+        builder.Property(s => s.UpdatedAt).IsRequired();
+
+        builder.HasIndex(s => s.Symbol)
+            .IsUnique()
+            .HasDatabaseName("IX_SymbolSnapshots_Symbol");
+    }
+}

--- a/Infrastructure/Persistence/Configurations/TrackedSymbolConfiguration.cs
+++ b/Infrastructure/Persistence/Configurations/TrackedSymbolConfiguration.cs
@@ -20,6 +20,12 @@ public class TrackedSymbolConfiguration : IEntityTypeConfiguration<TrackedSymbol
             .HasMaxLength(10)
             .IsRequired();
 
+        builder.Property(s => s.Source)
+            .HasColumnName("Source")
+            .HasMaxLength(20)
+            .HasDefaultValue("seed")
+            .IsRequired();
+
         builder.Property(s => s.AddedAt)
             .HasColumnName("AddedAt")
             .IsRequired();

--- a/Infrastructure/Persistence/Repositories/SymbolSnapshotRepository.cs
+++ b/Infrastructure/Persistence/Repositories/SymbolSnapshotRepository.cs
@@ -1,0 +1,37 @@
+using Domain.Entities;
+using Domain.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.Persistence.Repositories;
+
+public class SymbolSnapshotRepository(AppDbContext db) : ISymbolSnapshotRepository
+{
+    public async Task<SymbolSnapshot?> GetBySymbolAsync(string symbol, CancellationToken ct = default) =>
+        await db.SymbolSnapshots.FirstOrDefaultAsync(s => s.Symbol == symbol, ct);
+
+    public async Task<IReadOnlyList<SymbolSnapshot>> GetAllAsync(CancellationToken ct = default) =>
+        await db.SymbolSnapshots.OrderBy(s => s.Symbol).ToListAsync(ct);
+
+    public async Task UpsertAsync(SymbolSnapshot snapshot, CancellationToken ct = default)
+    {
+        var existing = await db.SymbolSnapshots
+            .FirstOrDefaultAsync(s => s.Symbol == snapshot.Symbol, ct);
+
+        if (existing is null)
+            db.SymbolSnapshots.Add(snapshot);
+        else
+            db.Entry(existing).CurrentValues.SetValues(new
+            {
+                snapshot.Score,
+                snapshot.PreviousScore,
+                snapshot.Delta,
+                snapshot.Direction,
+                snapshot.Trend,
+                snapshot.Dispersion,
+                snapshot.ArticleCount,
+                snapshot.UpdatedAt
+            });
+
+        await db.SaveChangesAsync(ct);
+    }
+}

--- a/Infrastructure/Persistence/Repositories/TrackedSymbolRepository.cs
+++ b/Infrastructure/Persistence/Repositories/TrackedSymbolRepository.cs
@@ -11,12 +11,28 @@ public class TrackedSymbolRepository(AppDbContext db) : ITrackedSymbolRepository
             .OrderBy(s => s.Symbol)
             .ToListAsync(ct);
 
+    public async Task<IReadOnlyList<TrackedSymbol>> GetBySourceAsync(string source, CancellationToken ct = default) =>
+        await db.TrackedSymbols
+            .Where(s => s.Source == source)
+            .OrderBy(s => s.Symbol)
+            .ToListAsync(ct);
+
+    public async Task<TrackedSymbol?> GetBySymbolAsync(string symbol, CancellationToken ct = default) =>
+        await db.TrackedSymbols
+            .FirstOrDefaultAsync(s => s.Symbol == symbol.ToUpperInvariant(), ct);
+
     public Task<bool> ExistsAsync(string symbol, CancellationToken ct = default) =>
         db.TrackedSymbols.AnyAsync(s => s.Symbol == symbol, ct);
 
     public async Task AddAsync(TrackedSymbol symbol, CancellationToken ct = default)
     {
         db.TrackedSymbols.Add(symbol);
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task UpdateAsync(TrackedSymbol symbol, CancellationToken ct = default)
+    {
+        db.TrackedSymbols.Update(symbol);
         await db.SaveChangesAsync(ct);
     }
 

--- a/Infrastructure/Services/YahooSymbolValidationService.cs
+++ b/Infrastructure/Services/YahooSymbolValidationService.cs
@@ -1,0 +1,39 @@
+using System.Text.Json;
+using Application.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.Services;
+
+public class YahooSymbolValidationService(
+    HttpClient httpClient,
+    ILogger<YahooSymbolValidationService> logger) : ISymbolValidationService
+{
+    public async Task<bool> IsValidSymbolAsync(string symbol, CancellationToken ct = default)
+    {
+        var encoded = Uri.EscapeDataString(symbol.ToUpperInvariant());
+        var url = $"https://query1.finance.yahoo.com/v8/finance/chart/{encoded}?range=1d&interval=1d";
+
+        try
+        {
+            var response = await httpClient.GetAsync(url, ct);
+            if (!response.IsSuccessStatusCode)
+                return false;
+
+            var json = await response.Content.ReadAsStringAsync(ct);
+            using var doc = JsonDocument.Parse(json);
+
+            // Yahoo returns a valid chart result with a non-null "meta" section for real symbols.
+            // For invalid symbols, the result array is empty or contains an error.
+            var result = doc.RootElement
+                .GetProperty("chart")
+                .GetProperty("result");
+
+            return result.GetArrayLength() > 0;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Yahoo Finance validation failed for symbol {Symbol}", symbol);
+            return false;
+        }
+    }
+}

--- a/Infrastructure/Services/YahooSymbolValidationService.cs
+++ b/Infrastructure/Services/YahooSymbolValidationService.cs
@@ -30,9 +30,19 @@ public class YahooSymbolValidationService(
 
             return result.GetArrayLength() > 0;
         }
-        catch (Exception ex)
+        catch (HttpRequestException ex)
         {
-            logger.LogWarning(ex, "Yahoo Finance validation failed for symbol {Symbol}", symbol);
+            logger.LogWarning(ex, "Yahoo Finance HTTP error validating symbol {Symbol}", symbol);
+            return false;
+        }
+        catch (TaskCanceledException ex)
+        {
+            logger.LogWarning(ex, "Yahoo Finance request timed out for symbol {Symbol}", symbol);
+            return false;
+        }
+        catch (JsonException ex)
+        {
+            logger.LogWarning(ex, "Yahoo Finance returned invalid JSON for symbol {Symbol}", symbol);
             return false;
         }
     }

--- a/README.md
+++ b/README.md
@@ -144,6 +144,13 @@ FinancialSentimentAPI/
 
 ---
 
+## Documentation
+
+- [Scoring Model](docs/scoring-model.md) — how sentiment scores are computed (decay weighting, trend regression, dispersion, signal strength)
+- [Decision Log](docs/decision-log.md) — architectural decisions and past incidents
+
+---
+
 ## Key Design Decisions
 
 | Decision | Rationale |

--- a/Tests/Application/GetSentimentStatsHandlerTests.cs
+++ b/Tests/Application/GetSentimentStatsHandlerTests.cs
@@ -1,3 +1,4 @@
+using Application.Configuration;
 using Application.Exceptions;
 using Application.Features.Sentiment.Queries.GetSentimentStats;
 using Domain.Entities;
@@ -12,7 +13,7 @@ public class GetSentimentStatsHandlerTests
 {
     private readonly ISentimentRepository _repository = Substitute.For<ISentimentRepository>();
 
-    private GetSentimentStatsQueryHandler CreateHandler() => new(_repository);
+    private GetSentimentStatsQueryHandler CreateHandler() => new(_repository, new SentimentScoringOptions());
 
     private static SentimentAnalysis CreateAnalysis(double score = 0.5, DateTime? analyzedAt = null)
     {

--- a/Tests/Application/GetTrendingSymbolsHandlerTests.cs
+++ b/Tests/Application/GetTrendingSymbolsHandlerTests.cs
@@ -1,3 +1,4 @@
+using Application.Configuration;
 using Application.Features.Sentiment.Queries.GetTrendingSymbols;
 using Domain.Entities;
 using Domain.Interfaces;
@@ -19,7 +20,7 @@ public class GetTrendingSymbolsHandlerTests
             .Returns(new List<SymbolSnapshot>());
     }
 
-    private GetTrendingSymbolsQueryHandler CreateHandler() => new(_repository, _snapshotRepository);
+    private GetTrendingSymbolsQueryHandler CreateHandler() => new(_repository, _snapshotRepository, new SentimentScoringOptions());
 
     private static SentimentAnalysis MakeAnalysis(string symbol, double score, DateTime analyzedAt)
     {

--- a/Tests/Application/GetTrendingSymbolsHandlerTests.cs
+++ b/Tests/Application/GetTrendingSymbolsHandlerTests.cs
@@ -128,15 +128,15 @@ public class GetTrendingSymbolsHandlerTests
     }
 
     [Fact]
-    public async Task Handle_MultipleSymbols_OrderedByAbsoluteDeltaDescending()
+    public async Task Handle_MultipleSymbols_OrderedByScoreDescending()
     {
         var now = DateTime.UtcNow;
 
-        var aaplPrev    = MakeAnalysis("AAPL", 0.4, now.AddHours(-20));
-        var aaplCurrent = MakeAnalysis("AAPL", 0.5, now.AddHours(-2));
+        var aaplPrev    = MakeAnalysis("AAPL", 0.2, now.AddHours(-20));
+        var aaplCurrent = MakeAnalysis("AAPL", 0.3, now.AddHours(-2));
 
-        var tslaPrev    = MakeAnalysis("TSLA", -0.4, now.AddHours(-20));
-        var tslaCurrent = MakeAnalysis("TSLA",  0.5, now.AddHours(-2));
+        var tslaPrev    = MakeAnalysis("TSLA", 0.6, now.AddHours(-20));
+        var tslaCurrent = MakeAnalysis("TSLA", 0.8, now.AddHours(-2));
 
         _repository.GetRecentAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
             .Returns([aaplPrev, aaplCurrent, tslaPrev, tslaCurrent]);
@@ -149,7 +149,7 @@ public class GetTrendingSymbolsHandlerTests
     }
 
     [Fact]
-    public async Task Handle_MixedPositiveAndNegativeDeltas_OrderedByAbsoluteDeltaDescending()
+    public async Task Handle_MixedScores_OrderedByScoreDescending()
     {
         var now = DateTime.UtcNow;
 
@@ -168,15 +168,10 @@ public class GetTrendingSymbolsHandlerTests
         var result = await CreateHandler().Handle(new GetTrendingSymbolsQuery(24, 10), CancellationToken.None);
 
         result.Should().HaveCount(3);
-        result[0].Symbol.Should().Be("GOOG");
-        result[0].Direction.Should().Be("down");
-        result[0].Delta.Should().BeApproximately(-0.9, 0.05);
-        result[1].Symbol.Should().Be("MSFT");
-        result[1].Direction.Should().Be("up");
-        result[1].Delta.Should().BeApproximately(0.5, 0.05);
-        result[2].Symbol.Should().Be("AAPL");
-        result[2].Direction.Should().Be("down");
-        result[2].Delta.Should().BeApproximately(-0.2, 0.05);
+        // Ordered by score desc: MSFT (0.5) > AAPL (0.1) > GOOG (-0.4)
+        result[0].Symbol.Should().Be("MSFT");
+        result[1].Symbol.Should().Be("AAPL");
+        result[2].Symbol.Should().Be("GOOG");
     }
 
     [Fact]
@@ -311,15 +306,15 @@ public class GetTrendingSymbolsHandlerTests
     }
 
     [Fact]
-    public async Task Handle_DefaultSortWithNullParams_SameAsAbsDeltaDesc()
+    public async Task Handle_DefaultSortWithNullParams_SameAsScoreDesc()
     {
         var now = DateTime.UtcNow;
 
-        var aaplPrev    = MakeAnalysis("AAPL", 0.4, now.AddHours(-20));
-        var aaplCurrent = MakeAnalysis("AAPL", 0.5, now.AddHours(-2));
+        var aaplPrev    = MakeAnalysis("AAPL", 0.2, now.AddHours(-20));
+        var aaplCurrent = MakeAnalysis("AAPL", 0.3, now.AddHours(-2));
 
-        var tslaPrev    = MakeAnalysis("TSLA", -0.4, now.AddHours(-20));
-        var tslaCurrent = MakeAnalysis("TSLA",  0.5, now.AddHours(-2));
+        var tslaPrev    = MakeAnalysis("TSLA", 0.6, now.AddHours(-20));
+        var tslaCurrent = MakeAnalysis("TSLA", 0.8, now.AddHours(-2));
 
         _repository.GetRecentAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
             .Returns([aaplPrev, aaplCurrent, tslaPrev, tslaCurrent]);

--- a/Tests/Application/GetTrendingSymbolsHandlerTests.cs
+++ b/Tests/Application/GetTrendingSymbolsHandlerTests.cs
@@ -10,8 +10,16 @@ namespace Tests.Application;
 public class GetTrendingSymbolsHandlerTests
 {
     private readonly ISentimentRepository _repository = Substitute.For<ISentimentRepository>();
+    private readonly ISymbolSnapshotRepository _snapshotRepository = Substitute.For<ISymbolSnapshotRepository>();
 
-    private GetTrendingSymbolsQueryHandler CreateHandler() => new(_repository);
+    public GetTrendingSymbolsHandlerTests()
+    {
+        // Default: no snapshots → tests exercise the fallback (live computation) path
+        _snapshotRepository.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<SymbolSnapshot>());
+    }
+
+    private GetTrendingSymbolsQueryHandler CreateHandler() => new(_repository, _snapshotRepository);
 
     private static SentimentAnalysis MakeAnalysis(string symbol, double score, DateTime analyzedAt)
     {

--- a/Tests/Application/RefreshSnapshotHandlerTests.cs
+++ b/Tests/Application/RefreshSnapshotHandlerTests.cs
@@ -1,0 +1,97 @@
+using Application.Features.Sentiment.Commands.AnalyzeSentiment;
+using Domain.Entities;
+using Domain.Interfaces;
+using Domain.ValueObjects;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Tests.Application;
+
+public class RefreshSnapshotHandlerTests
+{
+    private readonly ISentimentRepository _sentimentRepo = Substitute.For<ISentimentRepository>();
+    private readonly ISymbolSnapshotRepository _snapshotRepo = Substitute.For<ISymbolSnapshotRepository>();
+
+    private RefreshSnapshotHandler CreateHandler() =>
+        new(_sentimentRepo, _snapshotRepo, NullLogger<RefreshSnapshotHandler>.Instance);
+
+    private static SentimentAnalysis MakeAnalysis(string symbol, double score, DateTime analyzedAt)
+    {
+        var analysis = SentimentAnalysis.Create(
+            new StockSymbol(symbol), "Test text.", null, score, 0.9, [], "test-model");
+
+        typeof(SentimentAnalysis)
+            .GetProperty(nameof(SentimentAnalysis.AnalyzedAt))!
+            .SetValue(analysis, analyzedAt);
+
+        return analysis;
+    }
+
+    [Fact]
+    public async Task Handle_NewSymbol_CreatesSnapshot()
+    {
+        var now = DateTime.UtcNow;
+        var analyses = new List<SentimentAnalysis>
+        {
+            MakeAnalysis("AAPL", 0.7, now.AddHours(-1))
+        };
+
+        _sentimentRepo.GetForStatsAsync(
+                Arg.Is<StockSymbol>(s => s.Value == "AAPL"), 7, Arg.Any<CancellationToken>())
+            .Returns(analyses.AsReadOnly() as IReadOnlyList<SentimentAnalysis>);
+
+        _snapshotRepo.GetBySymbolAsync("AAPL", Arg.Any<CancellationToken>())
+            .Returns((SymbolSnapshot?)null);
+
+        var notification = new SentimentAnalysisCreatedNotification(Guid.NewGuid(), "AAPL");
+        await CreateHandler().Handle(notification, CancellationToken.None);
+
+        await _snapshotRepo.Received(1).UpsertAsync(
+            Arg.Is<SymbolSnapshot>(s => s.Symbol == "AAPL" && s.ArticleCount == 1),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ExistingSymbol_UpdatesSnapshot()
+    {
+        var now = DateTime.UtcNow;
+        var analyses = new List<SentimentAnalysis>
+        {
+            MakeAnalysis("TSLA", 0.5, now.AddHours(-1)),
+            MakeAnalysis("TSLA", 0.3, now.AddHours(-2)),
+        };
+
+        _sentimentRepo.GetForStatsAsync(
+                Arg.Is<StockSymbol>(s => s.Value == "TSLA"), 7, Arg.Any<CancellationToken>())
+            .Returns(analyses.AsReadOnly() as IReadOnlyList<SentimentAnalysis>);
+
+        var existing = SymbolSnapshot.Create("TSLA", 0.3, 0.0, 0.3, "up", "Stable", 0.0, 1);
+        _snapshotRepo.GetBySymbolAsync("TSLA", Arg.Any<CancellationToken>())
+            .Returns(existing);
+
+        var notification = new SentimentAnalysisCreatedNotification(Guid.NewGuid(), "TSLA");
+        await CreateHandler().Handle(notification, CancellationToken.None);
+
+        existing.ArticleCount.Should().Be(2);
+        await _snapshotRepo.Received(1).UpsertAsync(existing, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_NoAnalyses_CreatesSnapshotWithZeros()
+    {
+        _sentimentRepo.GetForStatsAsync(
+                Arg.Any<StockSymbol>(), 7, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<SentimentAnalysis>() as IReadOnlyList<SentimentAnalysis>);
+
+        _snapshotRepo.GetBySymbolAsync("GOOG", Arg.Any<CancellationToken>())
+            .Returns((SymbolSnapshot?)null);
+
+        var notification = new SentimentAnalysisCreatedNotification(Guid.NewGuid(), "GOOG");
+        await CreateHandler().Handle(notification, CancellationToken.None);
+
+        await _snapshotRepo.Received(1).UpsertAsync(
+            Arg.Is<SymbolSnapshot>(s => s.Symbol == "GOOG" && s.Score == 0 && s.ArticleCount == 0),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/Tests/Application/RefreshSnapshotHandlerTests.cs
+++ b/Tests/Application/RefreshSnapshotHandlerTests.cs
@@ -1,3 +1,4 @@
+using Application.Configuration;
 using Application.Features.Sentiment.Commands.AnalyzeSentiment;
 using Domain.Entities;
 using Domain.Interfaces;
@@ -14,7 +15,7 @@ public class RefreshSnapshotHandlerTests
     private readonly ISymbolSnapshotRepository _snapshotRepo = Substitute.For<ISymbolSnapshotRepository>();
 
     private RefreshSnapshotHandler CreateHandler() =>
-        new(_sentimentRepo, _snapshotRepo, NullLogger<RefreshSnapshotHandler>.Instance);
+        new(_sentimentRepo, _snapshotRepo, new SentimentScoringOptions(), NullLogger<RefreshSnapshotHandler>.Instance);
 
     private static SentimentAnalysis MakeAnalysis(string symbol, double score, DateTime analyzedAt)
     {

--- a/Tests/Application/RefreshSnapshotHandlerTests.cs
+++ b/Tests/Application/RefreshSnapshotHandlerTests.cs
@@ -39,7 +39,7 @@ public class RefreshSnapshotHandlerTests
         };
 
         _sentimentRepo.GetForStatsAsync(
-                Arg.Is<StockSymbol>(s => s.Value == "AAPL"), 7, Arg.Any<CancellationToken>())
+                Arg.Is<StockSymbol>(s => s.Value == "AAPL"), Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(analyses.AsReadOnly() as IReadOnlyList<SentimentAnalysis>);
 
         _snapshotRepo.GetBySymbolAsync("AAPL", Arg.Any<CancellationToken>())
@@ -64,7 +64,7 @@ public class RefreshSnapshotHandlerTests
         };
 
         _sentimentRepo.GetForStatsAsync(
-                Arg.Is<StockSymbol>(s => s.Value == "TSLA"), 7, Arg.Any<CancellationToken>())
+                Arg.Is<StockSymbol>(s => s.Value == "TSLA"), Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(analyses.AsReadOnly() as IReadOnlyList<SentimentAnalysis>);
 
         var existing = SymbolSnapshot.Create("TSLA", 0.3, 0.0, 0.3, "up", "Stable", 0.0, 1);
@@ -82,7 +82,7 @@ public class RefreshSnapshotHandlerTests
     public async Task Handle_NoAnalyses_CreatesSnapshotWithZeros()
     {
         _sentimentRepo.GetForStatsAsync(
-                Arg.Any<StockSymbol>(), 7, Arg.Any<CancellationToken>())
+                Arg.Any<StockSymbol>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(Array.Empty<SentimentAnalysis>() as IReadOnlyList<SentimentAnalysis>);
 
         _snapshotRepo.GetBySymbolAsync("GOOG", Arg.Any<CancellationToken>())

--- a/Tests/Application/WatchlistHandlerTests.cs
+++ b/Tests/Application/WatchlistHandlerTests.cs
@@ -166,12 +166,12 @@ public class GetWatchlistHandlerTests
             SentimentAnalysis.Create(new StockSymbol("GOOG"), "Good news", null, 0.8, 0.9, [], "test")
         };
         _sentimentRepo.GetForStatsAsync(
-            Arg.Is<StockSymbol>(s => s.Value == "GOOG"), 7, Arg.Any<CancellationToken>())
+            Arg.Is<StockSymbol>(s => s.Value == "GOOG"), Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(googAnalyses.AsReadOnly() as IReadOnlyList<SentimentAnalysis>);
 
         // TSLA has no sentiment data
         _sentimentRepo.GetForStatsAsync(
-            Arg.Is<StockSymbol>(s => s.Value == "TSLA"), 7, Arg.Any<CancellationToken>())
+            Arg.Is<StockSymbol>(s => s.Value == "TSLA"), Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(Array.Empty<SentimentAnalysis>() as IReadOnlyList<SentimentAnalysis>);
 
         var result = await CreateHandler().Handle(new GetWatchlistQuery(), CancellationToken.None);

--- a/Tests/Application/WatchlistHandlerTests.cs
+++ b/Tests/Application/WatchlistHandlerTests.cs
@@ -134,8 +134,9 @@ public class GetWatchlistHandlerTests
 {
     private readonly ITrackedSymbolRepository _trackedRepo = Substitute.For<ITrackedSymbolRepository>();
     private readonly ISentimentRepository _sentimentRepo = Substitute.For<ISentimentRepository>();
+    private readonly ISymbolSnapshotRepository _snapshotRepo = Substitute.For<ISymbolSnapshotRepository>();
 
-    private GetWatchlistQueryHandler CreateHandler() => new(_trackedRepo, _sentimentRepo);
+    private GetWatchlistQueryHandler CreateHandler() => new(_trackedRepo, _sentimentRepo, _snapshotRepo);
 
     [Fact]
     public async Task Handle_NoWatchlistSymbols_ReturnsEmpty()

--- a/Tests/Application/WatchlistHandlerTests.cs
+++ b/Tests/Application/WatchlistHandlerTests.cs
@@ -1,3 +1,4 @@
+using Application.Configuration;
 using Application.Exceptions;
 using Application.Features.Watchlist.Commands.AddToWatchlist;
 using Application.Features.Watchlist.Commands.RemoveFromWatchlist;
@@ -136,7 +137,7 @@ public class GetWatchlistHandlerTests
     private readonly ISentimentRepository _sentimentRepo = Substitute.For<ISentimentRepository>();
     private readonly ISymbolSnapshotRepository _snapshotRepo = Substitute.For<ISymbolSnapshotRepository>();
 
-    private GetWatchlistQueryHandler CreateHandler() => new(_trackedRepo, _sentimentRepo, _snapshotRepo);
+    private GetWatchlistQueryHandler CreateHandler() => new(_trackedRepo, _sentimentRepo, _snapshotRepo, new SentimentScoringOptions());
 
     [Fact]
     public async Task Handle_NoWatchlistSymbols_ReturnsEmpty()

--- a/Tests/Application/WatchlistHandlerTests.cs
+++ b/Tests/Application/WatchlistHandlerTests.cs
@@ -1,0 +1,185 @@
+using Application.Exceptions;
+using Application.Features.Watchlist.Commands.AddToWatchlist;
+using Application.Features.Watchlist.Commands.RemoveFromWatchlist;
+using Application.Features.Watchlist.Queries.GetWatchlist;
+using Application.Services;
+using Domain.Entities;
+using Domain.Interfaces;
+using Domain.ValueObjects;
+using FluentAssertions;
+// FluentValidation used via full qualifier in assertions
+using NSubstitute;
+
+namespace Tests.Application;
+
+public class AddToWatchlistHandlerTests
+{
+    private readonly ITrackedSymbolRepository _repository = Substitute.For<ITrackedSymbolRepository>();
+    private readonly ISymbolValidationService _validation = Substitute.For<ISymbolValidationService>();
+
+    private AddToWatchlistCommandHandler CreateHandler() => new(_repository, _validation);
+
+    [Fact]
+    public async Task Handle_NewValidSymbol_AddsWithWatchlistSource()
+    {
+        _repository.GetBySymbolAsync("GOOG", Arg.Any<CancellationToken>()).Returns((TrackedSymbol?)null);
+        _validation.IsValidSymbolAsync("GOOG", Arg.Any<CancellationToken>()).Returns(true);
+
+        var result = await CreateHandler().Handle(
+            new AddToWatchlistCommand("goog"), CancellationToken.None);
+
+        result.Symbol.Should().Be("GOOG");
+        await _repository.Received(1).AddAsync(
+            Arg.Is<TrackedSymbol>(s => s.Symbol == "GOOG" && s.Source == "watchlist"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_InvalidSymbol_ThrowsValidationException()
+    {
+        _repository.GetBySymbolAsync("FAKE", Arg.Any<CancellationToken>()).Returns((TrackedSymbol?)null);
+        _validation.IsValidSymbolAsync("FAKE", Arg.Any<CancellationToken>()).Returns(false);
+
+        var act = () => CreateHandler().Handle(
+            new AddToWatchlistCommand("FAKE"), CancellationToken.None);
+
+        await act.Should().ThrowAsync<global::Application.Exceptions.ValidationException>();
+    }
+
+    [Fact]
+    public async Task Handle_ExistingSeedSymbol_PromotesToWatchlist()
+    {
+        var existing = TrackedSymbol.Create("AAPL", "seed");
+        _repository.GetBySymbolAsync("AAPL", Arg.Any<CancellationToken>()).Returns(existing);
+
+        var result = await CreateHandler().Handle(
+            new AddToWatchlistCommand("AAPL"), CancellationToken.None);
+
+        result.Symbol.Should().Be("AAPL");
+        existing.Source.Should().Be("watchlist");
+        await _repository.Received(1).UpdateAsync(existing, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ExistingWatchlistSymbol_ReturnsWithoutModifying()
+    {
+        var existing = TrackedSymbol.Create("TSLA", "watchlist");
+        _repository.GetBySymbolAsync("TSLA", Arg.Any<CancellationToken>()).Returns(existing);
+
+        var result = await CreateHandler().Handle(
+            new AddToWatchlistCommand("TSLA"), CancellationToken.None);
+
+        result.Symbol.Should().Be("TSLA");
+        await _repository.DidNotReceive().UpdateAsync(Arg.Any<TrackedSymbol>(), Arg.Any<CancellationToken>());
+        await _repository.DidNotReceive().AddAsync(Arg.Any<TrackedSymbol>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_NewSymbol_DoesNotCallValidationForExisting()
+    {
+        var existing = TrackedSymbol.Create("AAPL", "seed");
+        _repository.GetBySymbolAsync("AAPL", Arg.Any<CancellationToken>()).Returns(existing);
+
+        await CreateHandler().Handle(new AddToWatchlistCommand("AAPL"), CancellationToken.None);
+
+        await _validation.DidNotReceive().IsValidSymbolAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+}
+
+public class RemoveFromWatchlistHandlerTests
+{
+    private readonly ITrackedSymbolRepository _repository = Substitute.For<ITrackedSymbolRepository>();
+
+    private RemoveFromWatchlistCommandHandler CreateHandler() => new(_repository);
+
+    [Fact]
+    public async Task Handle_WatchlistSymbol_RemovesSuccessfully()
+    {
+        var existing = TrackedSymbol.Create("GOOG", "watchlist");
+        _repository.GetBySymbolAsync("GOOG", Arg.Any<CancellationToken>()).Returns(existing);
+        _repository.RemoveAsync("GOOG", Arg.Any<CancellationToken>()).Returns(true);
+
+        var act = () => CreateHandler().Handle(
+            new RemoveFromWatchlistCommand("goog"), CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+        await _repository.Received(1).RemoveAsync("GOOG", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_SeedSymbol_ThrowsNotFoundException()
+    {
+        var existing = TrackedSymbol.Create("AAPL", "seed");
+        _repository.GetBySymbolAsync("AAPL", Arg.Any<CancellationToken>()).Returns(existing);
+
+        var act = () => CreateHandler().Handle(
+            new RemoveFromWatchlistCommand("AAPL"), CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_NonExistentSymbol_ThrowsNotFoundException()
+    {
+        _repository.GetBySymbolAsync("XXXX", Arg.Any<CancellationToken>()).Returns((TrackedSymbol?)null);
+
+        var act = () => CreateHandler().Handle(
+            new RemoveFromWatchlistCommand("XXXX"), CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+}
+
+public class GetWatchlistHandlerTests
+{
+    private readonly ITrackedSymbolRepository _trackedRepo = Substitute.For<ITrackedSymbolRepository>();
+    private readonly ISentimentRepository _sentimentRepo = Substitute.For<ISentimentRepository>();
+
+    private GetWatchlistQueryHandler CreateHandler() => new(_trackedRepo, _sentimentRepo);
+
+    [Fact]
+    public async Task Handle_NoWatchlistSymbols_ReturnsEmpty()
+    {
+        _trackedRepo.GetBySourceAsync("watchlist", Arg.Any<CancellationToken>())
+            .Returns(new List<TrackedSymbol>());
+
+        var result = await CreateHandler().Handle(new GetWatchlistQuery(), CancellationToken.None);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_WithSymbols_ReturnsEnrichedDtos()
+    {
+        var symbols = new List<TrackedSymbol>
+        {
+            TrackedSymbol.Create("GOOG", "watchlist"),
+            TrackedSymbol.Create("TSLA", "watchlist")
+        };
+        _trackedRepo.GetBySourceAsync("watchlist", Arg.Any<CancellationToken>()).Returns(symbols);
+
+        // GOOG has sentiment data
+        var googAnalyses = new List<SentimentAnalysis>
+        {
+            SentimentAnalysis.Create(new StockSymbol("GOOG"), "Good news", null, 0.8, 0.9, [], "test")
+        };
+        _sentimentRepo.GetForStatsAsync(
+            Arg.Is<StockSymbol>(s => s.Value == "GOOG"), 7, Arg.Any<CancellationToken>())
+            .Returns(googAnalyses.AsReadOnly() as IReadOnlyList<SentimentAnalysis>);
+
+        // TSLA has no sentiment data
+        _sentimentRepo.GetForStatsAsync(
+            Arg.Is<StockSymbol>(s => s.Value == "TSLA"), 7, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<SentimentAnalysis>() as IReadOnlyList<SentimentAnalysis>);
+
+        var result = await CreateHandler().Handle(new GetWatchlistQuery(), CancellationToken.None);
+
+        result.Should().HaveCount(2);
+        result[0].Symbol.Should().Be("GOOG");
+        result[0].Score.Should().BeApproximately(0.8, 0.01);
+        result[0].ArticleCount.Should().Be(1);
+        result[1].Symbol.Should().Be("TSLA");
+        result[1].Score.Should().Be(0);
+        result[1].ArticleCount.Should().Be(0);
+    }
+}

--- a/Tests/Domain/TrackedSymbolTests.cs
+++ b/Tests/Domain/TrackedSymbolTests.cs
@@ -58,4 +58,41 @@ public class TrackedSymbolTests
         var b = TrackedSymbol.Create("AAPL");
         a.Id.Should().NotBe(b.Id);
     }
+
+    [Fact]
+    public void Create_DefaultSource_IsSeed()
+    {
+        var symbol = TrackedSymbol.Create("AAPL");
+        symbol.Source.Should().Be("seed");
+    }
+
+    [Fact]
+    public void Create_WatchlistSource_SetsCorrectly()
+    {
+        var symbol = TrackedSymbol.Create("GOOG", "watchlist");
+        symbol.Source.Should().Be("watchlist");
+    }
+
+    [Fact]
+    public void Create_InvalidSource_ThrowsDomainException()
+    {
+        var act = () => TrackedSymbol.Create("AAPL", "invalid");
+        act.Should().Throw<DomainException>().WithMessage("*seed*watchlist*");
+    }
+
+    [Fact]
+    public void UpdateSource_ValidSource_UpdatesCorrectly()
+    {
+        var symbol = TrackedSymbol.Create("AAPL", "seed");
+        symbol.UpdateSource("watchlist");
+        symbol.Source.Should().Be("watchlist");
+    }
+
+    [Fact]
+    public void UpdateSource_InvalidSource_ThrowsDomainException()
+    {
+        var symbol = TrackedSymbol.Create("AAPL");
+        var act = () => symbol.UpdateSource("bad");
+        act.Should().Throw<DomainException>().WithMessage("*seed*watchlist*");
+    }
 }

--- a/Tests/E2E/WatchlistEndpointTests.cs
+++ b/Tests/E2E/WatchlistEndpointTests.cs
@@ -1,0 +1,70 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+
+namespace Tests.E2E;
+
+[Trait("Category", "E2E")]
+public class WatchlistEndpointTests : IAsyncLifetime
+{
+    private readonly E2EWebApplicationFactory _factory;
+    private readonly HttpClient _client;
+
+    public WatchlistEndpointTests()
+    {
+        _factory = new E2EWebApplicationFactory();
+        _factory.EnsureDatabaseCreated();
+        _client = _factory.CreateClient();
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
+    {
+        _client.Dispose();
+        await _factory.DisposeAsync();
+    }
+
+    private static StringContent JsonBody(object obj) =>
+        new(JsonSerializer.Serialize(obj), Encoding.UTF8, "application/json");
+
+    [Fact]
+    public async Task GetWatchlist_Empty_Returns200WithEmptyArray()
+    {
+        var response = await _client.GetAsync("/api/watchlist");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.ValueKind.Should().Be(JsonValueKind.Array);
+        doc.RootElement.GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task AddWatchlist_EmptySymbol_Returns422()
+    {
+        var body = JsonBody(new { symbol = "" });
+        var response = await _client.PostAsync("/api/watchlist", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task AddWatchlist_SpecialCharsSymbol_Returns422()
+    {
+        var body = JsonBody(new { symbol = "!!@@##" });
+        var response = await _client.PostAsync("/api/watchlist", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task DeleteWatchlist_NonExistent_Returns404()
+    {
+        var response = await _client.DeleteAsync("/api/watchlist/ZZZZZ");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/docs/scoring-model.md
+++ b/docs/scoring-model.md
@@ -1,0 +1,147 @@
+# Sentiment Scoring Model
+
+All scoring logic lives in `Application/Features/Sentiment/SentimentMath.cs`. Configuration is in `appsettings.json` under `SentimentScoring`.
+
+## Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `HalfLifeHours` | 36 | Hours for an article's weight to halve |
+| `DefaultWindowDays` | 14 | Data window for trending, watchlist, and snapshots |
+| `MaxDataAgeDays` | 30 | Maximum data age for stats queries |
+
+## Raw Score
+
+Each article is analyzed by the AI model and assigned a score between **-1.0** (bearish) and **+1.0** (bullish), along with a confidence value (0 to 1) and a label (Positive, Neutral, Negative).
+
+## Decay-Weighted Average
+
+The core of the scoring system. Recent articles matter more than old ones.
+
+Each article gets a weight based on its age:
+
+```
+weight = e^(-ln(2) / halfLifeHours * ageHours)
+```
+
+This is exponential decay with a configurable half-life (default 36 hours / 1.5 days). A 1.5-day-old article has half the influence of a brand-new one. A 3-day-old article has 25%.
+
+The weighted score for a set of articles:
+
+```
+score = sum(weight_i * score_i) / sum(weight_i)
+```
+
+## Symbol Stats (Trending / Watchlist / Snapshots)
+
+`ComputeSymbolStats` computes the full picture for a symbol. Used by the ingestion snapshot handler, trending fallback, and watchlist fallback.
+
+### Current vs Previous Score
+
+The data window is split at the midpoint:
+
+```
+window = DefaultWindowDays * 24 hours (default 336h)
+midpoint = now - window/2
+```
+
+- **Current score**: decay-weighted average of articles from `midpoint` to `now`, weighted relative to `now`
+- **Previous score**: decay-weighted average of articles before `midpoint`, weighted relative to `midpoint`
+
+### Delta and Direction
+
+```
+delta = currentScore - previousScore
+```
+
+| Delta | Direction |
+|-------|-----------|
+| > 0 | `"up"` |
+| < 0 | `"down"` |
+| = 0 | `"flat"` |
+
+## Trend (Linear Regression)
+
+Fits a line through all (day-offset, score) pairs using ordinary least squares:
+
+```
+slope = (n * sumXY - sumX * sumY) / (n * sumX^2 - sumX^2)
+```
+
+Where X = days since the oldest article, Y = raw score.
+
+| Slope | Direction |
+|-------|-----------|
+| > 0.005 | `"Improving"` |
+| < -0.005 | `"Deteriorating"` |
+| else | `"Stable"` |
+
+The slope represents score change per day. A slope of 0.01 means sentiment is improving by ~0.01 per day.
+
+## Dispersion (Weighted Standard Deviation)
+
+Measures how much articles disagree. High dispersion = conflicting sentiment.
+
+```
+mean = weighted average of all scores
+dispersion = sqrt(sum(weight_i * (score_i - mean)^2) / sum(weight_i))
+```
+
+- **0.0**: all articles agree
+- **> 0.5**: strong disagreement (e.g., some very bullish, some very bearish)
+
+## Signal Strength
+
+Based on the total decay weight (sum of all article weights):
+
+| Total Weight | Strength |
+|-------------|----------|
+| >= 3.0 | `"strong"` |
+| >= 1.0 | `"moderate"` |
+| < 1.0 | `"no signal"` |
+
+A single brand-new article has weight ~1.0. Three recent articles give ~3.0. Old articles contribute less.
+
+## Distribution
+
+Simple percentage breakdown of article labels:
+
+```
+positivePercent = (count of Positive) / total * 100
+neutralPercent  = (count of Neutral)  / total * 100
+negativePercent = (count of Negative) / total * 100
+```
+
+Not decay-weighted — every article in the window counts equally for distribution.
+
+## Sentiment Shift
+
+Compares the current weighted score to what the score *would have been* at two historical points:
+
+- **Vs24h**: current score minus the score computed using only articles that existed 24 hours ago (weighted relative to that point)
+- **Vs7d**: same but 7 days ago
+
+Returns `null` if no articles existed at the reference time.
+
+## Most Impactful Article
+
+The article with the highest `weight * |score|`. A high-confidence recent article with a strong score dominates. Used in the stats detail view.
+
+## Where Each Metric is Used
+
+| Metric | Trending | Watchlist | Stats Detail | Snapshot |
+|--------|----------|-----------|--------------|----------|
+| Score (weighted avg) | x | x | x | x |
+| Previous Score / Delta | x | | | x |
+| Direction | x | | | x |
+| Trend | x | x | x | x |
+| Dispersion | x | x | x | x |
+| Signal Strength | | | x | |
+| Distribution | | | x | |
+| Sentiment Shift | | | x | |
+| Most Impactful | | | x | |
+| Article Count | x | x | x | x |
+
+## Precomputed Snapshots
+
+`SymbolSnapshot` caches the output of `ComputeSymbolStats` in the database. It is refreshed on every new analysis (via `RefreshSnapshotHandler`). The trending and watchlist endpoints read snapshots for instant responses, falling back to live computation only on cold start when no snapshots exist yet.


### PR DESCRIPTION
## Summary
- **Server-side watchlist** — users can add/remove symbols via `POST/DELETE /api/watchlist`, stored as `TrackedSymbol` with `source = "watchlist"`
- **Yahoo Finance validation** — new symbols are validated against Yahoo Finance chart API before being accepted; invalid symbols return 422
- **Auto-ingestion** — watchlist symbols are automatically picked up by the existing ingestion pipeline (no changes needed)
- **Enriched data** — `GET /api/watchlist` returns decay-weighted score, trend (linear regression), dispersion, and article count for each symbol
- **Frontend** — watchlist section above trending table with add input, remove button, and "+" button on trending rows to quick-add
- **Seed promotion** — adding an already-tracked seed symbol promotes it to watchlist without duplication

## Architecture
- `TrackedSymbol` entity extended with `Source` column (seed/watchlist) + EF migration
- `ISymbolValidationService` (Application) / `YahooSymbolValidationService` (Infrastructure)
- CQRS: `AddToWatchlistCommand`, `RemoveFromWatchlistCommand`, `GetWatchlistQuery` with MediatR handlers
- `WatchlistController` (GET/POST/DELETE)
- 310 tests passing (19 new: domain, application, E2E)

## Test plan
- [x] `dotnet build` — zero errors
- [x] `dotnet test` — 310 tests pass
- [x] `POST /api/watchlist {"symbol":"GOOG"}` → 201, appears in watchlist
- [x] `POST /api/watchlist {"symbol":"FAKESYMBOL"}` → 422 validation error
- [x] `POST /api/watchlist {"symbol":"AAPL"}` → promotes seed to watchlist, enriched with sentiment data
- [x] `GET /api/watchlist` → returns symbols with score, trend, dispersion, articles
- [x] `DELETE /api/watchlist/GOOG` → 204, removed
- [x] Frontend: add via input, add via "+" on trending, remove via "×" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)