### PR TITLE
Add tini to reap zombie children in API and finbert containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 WORKDIR /app
 
 # Npgsql requires libgssapi for Kerberos probing (even when not used)
-RUN apt-get update && apt-get install -y --no-install-recommends libgssapi-krb5-2 curl && rm -rf /var/lib/apt/lists/*
+# tini reaps zombie children spawned by HEALTHCHECK curl and any other subprocesses
+RUN apt-get update && apt-get install -y --no-install-recommends libgssapi-krb5-2 curl tini && rm -rf /var/lib/apt/lists/*
 
 # Non-root user — .NET 10 images ship a built-in 'app' user (UID 1654)
 USER app
@@ -33,4 +34,4 @@ COPY --from=build /app/publish .
 ENV ASPNETCORE_URLS=http://+:8080
 EXPOSE 8080
 
-ENTRYPOINT ["dotnet", "API.dll"]
+ENTRYPOINT ["/usr/bin/tini", "--", "dotnet", "API.dll"]

--- a/finbert/Dockerfile
+++ b/finbert/Dockerfile
@@ -1,6 +1,7 @@
 FROM nvidia/cuda:12.4.1-runtime-ubuntu22.04
 
-RUN apt-get update && apt-get install -y python3 python3-pip && rm -rf /var/lib/apt/lists/*
+# tini reaps zombie children — Python subprocesses and uvicorn workers exit cleanly
+RUN apt-get update && apt-get install -y python3 python3-pip tini && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
@@ -14,4 +15,5 @@ RUN python3 -c "from transformers import AutoTokenizer, AutoModelForSequenceClas
 
 EXPOSE 8000
 
+ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- Add `tini` as PID 1 in both Dockerfiles to auto-reap zombie children.

## Why
On the TrueNAS host, both containers were accumulating zombie processes:
- `financial-sentiment-api-api`: ~26 `[curl] <defunct>` zombies/hour from the Docker `HEALTHCHECK` (curl spawned every minute, never reaped because dotnet runs as PID 1 and does not reap unrelated children).
- `finbert`: 71 `[python3] <defunct>` zombies over 6 days from uvicorn worker / model subprocess churn.

These were a contributing factor to a TrueNAS slowness incident (load avg 150+, 89% iowait). Restarting cleared the existing zombies; this PR prevents recurrence.

## Test plan
- [ ] CI builds both images
- [ ] Pull the new image on TrueNAS and let it run for a few hours
- [ ] Verify zombie count stays at 0: `ps -eo stat,pid | awk "$1 ~ /Z/" | wc -l`